### PR TITLE
Add git index section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Currently it shows:
   * `⇡` — ahead of remote branch;
   * `⇣` — behind of remote branch;
   * `⇕` — diverged chages.
+* Git index reminders:
+  * `⤒` - at least one file is `--assume-unchanged`;
+  * `↧` - at least one file is `--skip-worktree`.
 * Mercurial repo status:
   * `?` — untracked changes;
   * `+` — uncommitted changes in the index;
@@ -258,7 +261,7 @@ Directory is always shown and truncated to the value of `SPACESHIP_DIR_TRUNC`.
 
 ### Git (`git`)
 
-Git section is consists with `git_branch` and `git_status` subsections. It is shown only in Git repositories.
+Git section consists of `git_branch`, `git_status`, and `git_index` subsections. It is shown only in Git repositories.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
@@ -278,7 +281,7 @@ Git section is consists with `git_branch` and `git_status` subsections. It is sh
 
 #### Git status (`git_status`)
 
-Git status indicators is shown only when you have dirty repository.
+Git status indicators is shown only when you have a dirty repository.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
@@ -296,6 +299,19 @@ Git status indicators is shown only when you have dirty repository.
 | `SPACESHIP_GIT_STATUS_AHEAD` | `⇡` | Indicator for unpushed changes (ahead of remote branch) |
 | `SPACESHIP_GIT_STATUS_BEHIND` | `⇣` | Indicator for unpulled changes (behind of remote branch) |
 | `SPACESHIP_GIT_STATUS_DIVERGED` | `⇕` | Indicator for diverged chages (diverged with remote branch) |
+
+#### Git index (`git_index`)
+
+Git index indications is shown only when files in your repository have certain `git-update-index` options set.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_GIT_INDEX_SHOW` | `true` | Show Git index subsection |
+| `SPACESHIP_GIT_INDEX_PREFIX` | ` (` | Prefix before Git index subsection |
+| `SPACESHIP_GIT_INDEX_SUFFIX` | `)` | Suffix after Git index subsection |
+| `SPACESHIP_GIT_INDEX_COLOR` | `SPACESHIP_GIT_BRANCH_COLOR` | Color of Git index subsection |
+`SPACESHIP_GIT_INDEX_ASSUME_UNCHANGED` | `⤒` | Indicator for the presence of an `--assume-unchanged` file |
+`SPACESHIP_GIT_INDEX_SKIP_WORKTREE` | `↧` | Indicator for the presence of a `--skip-worktree` file |
 
 ### Mercurial (`hg`)
 

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -112,6 +112,13 @@ SPACESHIP_GIT_STATUS_UNMERGED="${SPACESHIP_GIT_STATUS_UNMERGED:="="}"
 SPACESHIP_GIT_STATUS_AHEAD="${SPACESHIP_GIT_STATUS_AHEAD:="⇡"}"
 SPACESHIP_GIT_STATUS_BEHIND="${SPACESHIP_GIT_STATUS_BEHIND:="⇣"}"
 SPACESHIP_GIT_STATUS_DIVERGED="${SPACESHIP_GIT_STATUS_DIVERGED:="⇕"}"
+# GIT INDEX
+SPACESHIP_GIT_INDEX_SHOW="${SPACESHIP_GIT_INDEX_SHOW:=true}"
+SPACESHIP_GIT_INDEX_PREFIX="${SPACESHIP_GIT_INDEX_PREFIX:=" ("}"
+SPACESHIP_GIT_INDEX_SUFFIX="${SPACESHIP_GIT_INDEX_SUFFIX:=")"}"
+SPACESHIP_GIT_INDEX_COLOR="${SPACESHIP_GIT_INDEX_COLOR:="$SPACESHIP_GIT_BRANCH_COLOR"}"
+SPACESHIP_GIT_INDEX_ASSUME_UNCHANGED="${SPACESHIP_GIT_INDEX_ASSUME_UNCHANGED:="⤒"}"
+SPACESHIP_GIT_INDEX_SKIP_WORKTREE="${SPACESHIP_GIT_INDEX_SKIP_WORKTREE:="↧"}"
 
 # MERCURIAL
 SPACESHIP_HG_SHOW="${SPACESHIP_HG_SHOW:=true}"
@@ -530,21 +537,50 @@ spaceship_git_status() {
   fi
 }
 
+# GIT INDEX
+# Check for files flagged with particular git-update-index options
+spaceship_git_index() {
+  [[ $SPACESHIP_GIT_INDEX_SHOW == false ]] && return
+
+  _is_git || return
+
+  spaceship_git_index_assume_unchanged() {
+    if [ -n "$(git ls-files -v `git rev-parse --show-toplevel` | grep '^[[:lower:]]')" ]; then
+      echo -n "${SPACESHIP_GIT_INDEX_ASSUME_UNCHANGED}"
+    fi
+  }
+
+  spaceship_git_index_skip_worktree() {
+    if [ -n "$(git ls-files -v `git rev-parse --show-toplevel` | grep '^[sS]')" ]; then
+      echo -n "${SPACESHIP_GIT_INDEX_SKIP_WORKTREE}"
+    fi
+  }
+
+  local git_index="$(spaceship_git_index_assume_unchanged)$(spaceship_git_index_skip_worktree)"
+
+  if [[ -n $git_index ]]; then
+    _prompt_section \
+      "$SPACESHIP_GIT_INDEX_COLOR" \
+      "$SPACESHIP_GIT_INDEX_PREFIX$git_index$SPACESHIP_GIT_INDEX_SUFFIX"
+  fi
+}
+
 # GIT
-# Show both git branch and git status:
+# Show git branch, git status, and git index:
 #   spaceship_git_branch
 #   spaceship_git_status
+#   spaceship_git_index
 spaceship_git() {
   [[ $SPACESHIP_GIT_SHOW == false ]] && return
 
-  local git_branch="$(spaceship_git_branch)" git_status="$(spaceship_git_status)"
+  local git_branch="$(spaceship_git_branch)" git_status="$(spaceship_git_status)" git_index="$(spaceship_git_index)"
 
   [[ -z $git_branch ]] && return
 
   _prompt_section \
     'white' \
     "$SPACESHIP_GIT_PREFIX" \
-    "${git_branch}${git_status}" \
+    "${git_branch}${git_status}${git_index}" \
     "$SPACESHIP_GIT_SUFFIX"
 }
 


### PR DESCRIPTION
This adds a git index subsection to the git status section. Markers are added to the prompt if any files in the repo have been marked as `--assume-unchanged` or `--skip-worktree` (a file that is both `--assume-unchanged` and `--skip-worktree` turns on both prompt markers).

This protects the user against forgetting about having marked a file or files `--assume-unchanged` or `--skip-worktree`. Those aren't things you want to forget you've done!

The subsection follows the git status subsection. By default it uses the same colors as the branch info. This helps distinguish it from the git status while showing that it's information about the repo.

The default symbols fit with the default git status symbols, and they roughly approximate what the flags do: `--assume-unchanged` won't upload any changes - `⤒` has a wall blocking off the upstream from upward pushes; `--skip-worktree` blocks won't upload changes but in some circumstances can allow pulling changes - `↧` has a wall blocking off the upstream but a clear path for downward pulls