### PR TITLE
Added mercurial bookmark Fixes #213

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Git status indicators is shown only when you have dirty repository.
 
 ### Mercurial (`hg`)
 
-Mercurial section is consists with `hg_branch` and `hg_status` subsections. It is shown only in Mercurial repositories.
+Mercurial section is consists of `hg_bookmark`, `hg_branch` and `hg_status` subsections. It is shown only in Mercurial repositories.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
@@ -309,6 +309,15 @@ Mercurial section is consists with `hg_branch` and `hg_status` subsections. It i
 | `SPACESHIP_HG_PREFIX` | `on ` | Prefix before Mercurial section |
 | `SPACESHIP_HG_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Mercurial section |
 | `SPACESHIP_HG_SYMBOL` | `☿ ` | Character to be shown before Mercurial section |
+
+#### Mercurial bookmark (`hg_bookmark`)
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_HG_BOOKMARK_SHOW` | `true` | Show Mercurial bookmark subsection |
+| `SPACESHIP_HG_BOOKMARK_PREFIX` | | Prefix before Mercurial bookmark subsection |
+| `SPACESHIP_HG_BOOKMARK_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Mercurial bookmark subsection |
+| `SPACESHIP_HG_BOOKMARK_COLOR` | `green` | Color of Mercurial bookmark subsection |
 
 #### Mercurial branch (`hg_branch`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "spaceship-zsh-theme",
+  "version": "2.10.2",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaceship-zsh-theme",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "An “Oh My ZSH!” theme for Astronauts.",
   "scripts": {
     "postinstall": "./install.zsh",

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -1026,8 +1026,15 @@ spaceship_ember() {
 # Show current context in kubectl.
 spaceship_kubecontext() {
   [[ $SPACESHIP_KUBECONTEXT_SHOW == false ]] && return
+  for kubecfg in ${(@s/:/)KUBECONFIG:-~/.kube/config}; do
+    if [[ -e $kubecfg ]]; then
+      local kube_config_file=$kubecfg
+    fi
+  done
 
-  local kube_context=$(awk -F' *: *' '$1 == "current-context" {print $2}' ~/.kube/config)
+  [ -z "${kube_config_file+1}" ] && return
+
+  local kube_context=$(awk -F' *: *' '$1 == "current-context" {print $2}' $kube_config_file)
 
   _prompt_section \
     "$SPACESHIP_KUBECONTEXT_COLOR" \

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -1026,15 +1026,10 @@ spaceship_ember() {
 # Show current context in kubectl.
 spaceship_kubecontext() {
   [[ $SPACESHIP_KUBECONTEXT_SHOW == false ]] && return
-  for kubecfg in ${(@s/:/)KUBECONFIG:-~/.kube/config}; do
-    if [[ -e $kubecfg ]]; then
-      local kube_config_file=$kubecfg
-    fi
-  done
 
-  [ -z "${kube_config_file+1}" ] && return
-
-  local kube_context=$(awk -F' *: *' '$1 == "current-context" {print $2}' $kube_config_file)
+  _exists kubectl || return
+  local kube_context=$(kubectl config current-context 2>/dev/null)
+  [[ -z $kube_context ]] && return
 
   _prompt_section \
     "$SPACESHIP_KUBECONTEXT_COLOR" \

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -119,10 +119,15 @@ SPACESHIP_HG_SHOW="${SPACESHIP_HG_SHOW:=true}"
 SPACESHIP_HG_PREFIX="${SPACESHIP_HG_PREFIX:="on "}"
 SPACESHIP_HG_SUFFIX="${SPACESHIP_HG_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_HG_SYMBOL="${SPACESHIP_HG_SYMBOL:="☿ "}"
+# MERCURIAL BOOKMARK
+SPACESHIP_HG_BOOKMARK_SHOW="${SPACESHIP_HG_BOOKMARK_SHOW:=true}"
+SPACESHIP_HG_BOOKMARK_PREFIX="${SPACESHIP_HG_BOOKMARK_PREFIX:=""}"
+SPACESHIP_HG_BOOKMARK_SUFFIX="${SPACESHIP_HG_BOOKMARK_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_HG_BOOKMARK_COLOR="${SPACESHIP_HG_BOOKMARK_COLOR:="green"}"
 # MERCURIAL BRANCH
 SPACESHIP_HG_BRANCH_SHOW="${SPACESHIP_HG_BRANCH_SHOW:=true}"
 SPACESHIP_HG_BRANCH_PREFIX="${SPACESHIP_HG_BRANCH_PREFIX:="$SPACESHIP_HG_SYMBOL"}"
-SPACESHIP_HG_BRANCH_SUFFIX="${SPACESHIP_HG_BRANCH_SUFFIX:=""}"
+SPACESHIP_HG_BRANCH_SUFFIX="${SPACESHIP_HG_BRANCH_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_HG_BRANCH_COLOR="${SPACESHIP_HG_BRANCH_COLOR:="magenta"}"
 # MERCURIAL STATUS
 SPACESHIP_HG_STATUS_SHOW="${SPACESHIP_HG_STATUS_SHOW:=true}"
@@ -556,6 +561,22 @@ spaceship_git() {
     "$SPACESHIP_GIT_SUFFIX"
 }
 
+# MERCURIAL BOOKMARK
+# Show current hg bookmark
+spaceship_hg_bookmark() {
+  [[ $SPACESHIP_HG_BOOKMARK_SHOW == false ]] && return
+
+  _is_hg || return
+
+  local BOOKMARK=$(hg log -r . -T '{activebookmark}')
+
+  [[ -z "$BOOKMARK" ]] && return
+
+  _prompt_section \
+    "$SPACESHIP_HG_BOOKMARK_COLOR" \
+    "$SPACESHIP_HG_BOOKMARK_PREFIX"$(hg log -r . -T '{activebookmark}')"$SPACESHIP_HG_BOOKMARK_SUFFIX"
+}
+
 # MERCURIAL BRANCH
 # Show current hg branch
 spaceship_hg_branch() {
@@ -597,20 +618,21 @@ spaceship_hg_status() {
 }
 
 # MERCURIAL
-# Show both hg branch and hg status:
+# Show hg branch, active hg bookmark and hg status:
+#   spaceship_hg_bookmark
 #   spaceship_hg_branch
 #   spaceship_hg_status
 spaceship_hg() {
   [[ $SPACESHIP_HG_SHOW == false ]] && return
 
-  local hg_branch="$(spaceship_hg_branch)" hg_status="$(spaceship_hg_status)"
+  local hg_branch="$(spaceship_hg_branch)" hg_status="$(spaceship_hg_status)" hg_bookmark="$(spaceship_hg_bookmark)"
 
-  [[ -z $hg_branch ]] && return
+  [[ -z $hg_branch ]] && [[ -z $hg_bookmark ]] && return
 
   _prompt_section \
     'white' \
     "$SPACESHIP_HG_PREFIX" \
-    "${hg_branch}${hg_status}" \
+    "${hg_branch}${hg_bookmark}${hg_status}" \
     "$SPACESHIP_HG_SUFFIX"
 }
 


### PR DESCRIPTION
The suffix was missing from the the hg branch section but wasn't needed until now so I have added it.

Hiding the branch when showing the bookmark doesn't really make sense as they are completely separate things so I display them both.

Here I am on the `default` branch at a bookmark called `1399493-update-react.diff`:
<img width="503" alt="mercurial bookmark" src="https://user-images.githubusercontent.com/116941/31548984-977727ca-b024-11e7-84f0-6dc978b2c686.png">
