### PR TITLE
Support $COMPOSE_FILE in spaceship_docker()

### DIFF
--- a/sections/docker.zsh
+++ b/sections/docker.zsh
@@ -25,7 +25,7 @@ spaceship_docker() {
   _exists docker || return
 
   # Show Docker status only for Docker-specific folders
-  [[ -f Dockerfile || -f docker-compose.yml ]] || return
+  [[ -f $COMPOSE_FILE || -f Dockerfile || -f docker-compose.yml ]] || return
 
   # if docker daemon isn't running you'll get an error saying it can't connect
   docker info 2>&1 | grep -q "Cannot connect" && return


### PR DESCRIPTION
Docker Compose supports explicitly settting `COMPOSE_FILE`
Cf. https://docs.docker.com/compose/reference/envvars/

If this env var is set, this change will use it as an alternative to `docker-compose.yml` in the current working directory. This is very useful for projects where the maintainers like to hide `docker-compose.yml` in a subdirectory instead of at the repo root.

Would you be kind enough to consider this change? Thanks.