### PR TITLE
Java / Gradle / Maven sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ SPACESHIP_PROMPT_ORDER=(
   rust          # Rust section
   haskell       # Haskell Stack section
   java          # Java section
+  gradle        # Gradle section
   julia         # Julia section
   docker        # Docker section
   aws           # Amazon Web Services section
@@ -414,6 +415,18 @@ Shows Java version.
 | `SPACESHIP_JAVA_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Java section |
 | `SPACESHIP_JAVA_SYMBOL` | `☕` | Character to be shown before Java version |
 | `SPACESHIP_JAVA_COLOR` | `magenta` | Color of Java section |
+
+### Gradle (`gradle` )
+
+Shows Gradle version.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_GRADLE_SHOW` | `true` | Show current Gradle version or not |
+| `SPACESHIP_GRADLE_PREFIX` | `on ` | Prefix before the Gradle section |
+| `SPACESHIP_GRADLE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Gradle section |
+| `SPACESHIP_GRADLE_SYMBOL` | `⬡` | Character to be shown before Gradle version |
+| `SPACESHIP_GRADLE_COLOR` | `green` | Color of Gradle section |
 
 ### Example
 
@@ -627,6 +640,13 @@ SPACESHIP_JAVA_PREFIX="on "
 SPACESHIP_JAVA_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
 SPACESHIP_JAVA_SYMBOL="☕ "
 SPACESHIP_JAVA_COLOR="magenta"
+
+# GRADLE
+SPACESHIP_GRADLE_SHOW=true
+SPACESHIP_GRADLE_PREFIX="on "
+SPACESHIP_GRADLE_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_GRADLE_SYMBOL="⬡ "
+SPACESHIP_GRADLE_COLOR="green"
 
 # JULIA
 SPACESHIP_JULIA_SHOW=true

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Currently it shows:
 * Current PHP version (`🐘`).
 * Current Rust version (`𝗥`).
 * Current version of Haskell Tool Stack (`λ`).
+* Current Java version (`☕`).
 * Current Julia version (`ஃ`).
 * Current Docker version and connected machine (`🐳`).
 * Current Amazon Web Services (AWS) profile (`☁️`) ([Using named profiles](http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html)).
@@ -184,7 +185,59 @@ autoload -U promptinit; promptinit
 prompt spaceship
 ```
 
+<<<<<<< HEAD
 ## Customization
+=======
+## Options
+
+Now you have ability to disable elements of Spaceship. All options must be overridden in your `.zshrc` file.
+
+Take a look at popular option presets or share your own configuration in [Presets](https://github.com/denysdovhan/spaceship-zsh-theme/wiki/Presets) wiki page.
+
+### Order
+
+You can specify the order of prompt section using `SPACESHIP_PROMPT_ORDER` option. Use zsh array syntax to define your own prompt order. The default order is:
+
+```zsh
+SPACESHIP_PROMPT_ORDER=(
+  time          # Time stampts section
+  user          # Username section
+  host          # Hostname section
+  dir           # Current directory section
+  git           # Git section (git_branch + git_status)
+  hg            # Mercurial section (hg_branch  + hg_status)
+  package       # Package version
+  node          # Node.js section
+  ruby          # Ruby section
+  elixir        # Elixir section
+  xcode         # Xcode section
+  swift         # Swift section
+  golang        # Go section
+  php           # PHP section
+  rust          # Rust section
+  haskell       # Haskell Stack section
+  java          # Java section
+  julia         # Julia section
+  docker        # Docker section
+  aws           # Amazon Web Services section
+  venv          # virtualenv section
+  conda         # conda virtualenv section
+  pyenv         # Pyenv section
+  dotnet        # .NET section
+  ember         # Ember.js section
+  kubecontext   # Kubectl context section
+  exec_time     # Execution time
+  line_sep      # Line break
+  battery       # Battery level and status
+  vi_mode       # Vi-mode indicator
+  jobs          # Backgound jobs indicator
+  exit_code     # Exit code section
+  char          # Prompt character
+)
+```
+
+You can also add items to the right side prompt by specifying them in the `SPACESHIP_RPROMPT_ORDER` option.
+>>>>>>> Support of java, 3.0 port of #139 @anton-johansson
 
 Spaceship works well out of the box, but you can customize almost everything if you want.
 
@@ -203,9 +256,473 @@ Still struggling? Please, [file an issue](https://github.com/denysdovhan/spacesh
 
 ## Team
 
+<<<<<<< HEAD
 | [![Denys Dovhan](https://github.com/denysdovhan.png?size=100)](http://denysdovhan.com) | [![Salmanul Farzy](https://github.com/salmanulfarzy.png?size=100)](https://github.com/salmanulfarzy) | [![Maxim Baz](https://github.com/maximbaz.png?size=100)](https://github.com/maximbaz) |
 | :---: | :---: | :---: |
 | [Denys Dovhan](https://github.com/denysdovhan) | [Salmanul Farzy](https://github.com/salmanulfarzy) | [Maxim Baz](https://github.com/maximbaz) |
+=======
+### Virtualenv (`venv`)
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_VENV_SHOW` | `true` | Show current Python virtualenv or not |
+| `SPACESHIP_VENV_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the virtualenv section |
+| `SPACESHIP_VENV_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the virtualenv section |
+| `SPACESHIP_VENV_COLOR` | `blue` | Color of virtualenv environment section |
+
+### Conda virtualenv (`conda`)
+
+Show activated conda virtual environment. Disable native conda prompt by `conda config --set changeps1 False`.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_CONDA_SHOW` | `true` | Show current Python conda virtualenv or not |
+| `SPACESHIP_CONDA_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the conda virtualenv section |
+| `SPACESHIP_CONDA_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the conda virtualenv section |
+| `SPACESHIP_CONDA_SYMBOL` | `🅒 ` | Character to be shown before conda virtualenv section |
+| `SPACESHIP_CONDA_COLOR` | `blue` | Color of conda virtualenv environment section |
+
+### Pyenv (`pyenv`)
+
+pyenv section is shown only in directories that contain `requirements.txt` or any other file with `.py` extension.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_PYENV_SHOW` | `true` | Show current Pyenv version or not |
+| `SPACESHIP_PYENV_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the pyenv section |
+| `SPACESHIP_PYENV_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the pyenv section |
+| `SPACESHIP_PYENV_SYMBOL` | `🐍 ` | Character to be shown before Pyenv version |
+| `SPACESHIP_PYENV_COLOR` | `yellow` | Color of Pyenv section |
+
+### .NET (`dotnet`)
+
+.NET section is shown only in directories that contains a `project.json` or `global.json` file, or a file with one of these extensions: `.csproj`, `.xproj` or `.sln`.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_DOTNET_SHOW` | `true` | Current .NET section |
+| `SPACESHIP_DOTNET_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before .NET section |
+| `SPACESHIP_DOTNET_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after .NET section |
+| `SPACESHIP_DOTNET_SYMBOL` | `.NET ` | Character to be shown before .NET version |
+| `SPACESHIP_DOTNET_COLOR` | `128` | [Color code](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg) of .NET section |
+
+### Ember.js (`ember`)
+
+Ember.js section is shown only in directories that contain a `ember-cli-build.js` file.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_EMBER_SHOW` | `true` | Current Ember.js section |
+| `SPACESHIP_EMBER_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Ember.js section |
+| `SPACESHIP_EMBER_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Ember.js section |
+| `SPACESHIP_EMBER_SYMBOL` | `🐹 ` | Character to be shown before Ember.js version |
+| `SPACESHIP_EMBER_COLOR` | `210` | Color of Ember.js section |
+
+### Kubectl context (`kubecontext`)
+
+Shows the active kubectl context.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_KUBECONTEXT_SHOW` | `true` | Current Kubectl context section |
+| `SPACESHIP_KUBECONTEXT_PREFIX` | `at ` | Prefix before Kubectl context section |
+| `SPACESHIP_KUBECONTEXT_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Kubectl context section |
+| `SPACESHIP_KUBECONTEXT_SYMBOL` | `☸️ ` | Character to be shown before Kubectl context |
+| `SPACESHIP_KUBECONTEXT_COLOR` | `cyan` | Color of Kubectl context section |
+
+### Execution time (`exec_time`)
+
+Execution time of the last command. Will be displayed if it exceeds the set threshold of time.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_EXEC_TIME_SHOW` | `true` | Show execution time |
+| `SPACESHIP_EXEC_TIME_PREFIX` | `took ` | Prefix before execution time section |
+| `SPACESHIP_EXEC_TIME_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after execution time section |
+| `SPACESHIP_EXEC_TIME_COLOR` | `yellow` | Color of execution time section |
+| `SPACESHIP_EXEC_TIME_ELAPSED` | `2` | The minimum number of seconds for showing execution time section |
+
+### Battery (`battery`)
+
+By default, Battery section is shown only if battery level is below `SPACESHIP_BATTERY_THRESHOLD` (default: 10%) or it's fully charged.  It can be made always visible by setting `SPACESHIP_BATTERY_ALWAYS_SHOW=true`.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_BATTERY_SHOW` | `true` | Show battery section or not |
+| `SPACESHIP_BATTERY_ALWAYS_SHOW` | `false` | Always show battery section or not |
+| `SPACESHIP_BATTERY_PREFIX` | `` | Prefix before battery section |
+| `SPACESHIP_BATTERY_SUFFIX` | `SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after battery section |
+| `SPACESHIP_BATTERY_CHARGING_SYMBOL` | `⇡` | Character to be shown if battery is charging |
+| `SPACESHIP_BATTERY_DISCHARGING_SYMBOL` | `⇣` | Character to be shown if battery is discharging |
+| `SPACESHIP_w_FULL_SYMBOL` | `•` | Character to be shown if battery is full |
+| `SPACESHIP_BATTERY_THRESHOLD` | 10 | Battery level below which battery section will be shown |
+
+### Vi-mode (`vi_mode`)
+
+This section shows mode indicator only when Vi-mode is enabled.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_VI_MODE_SHOW` | `true` | Shown current Vi-mode or not |
+| `SPACESHIP_VI_MODE_PREFIX` | `` | Prefix before Vi-mode section |
+| `SPACESHIP_VI_MODE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Vi-mode section |
+| `SPACESHIP_VI_MODE_INSERT` | `[I]` | Text to be shown when in insert mode |
+| `SPACESHIP_VI_MODE_NORMAL` | `[N]` | Text to be shown when in normal mode |
+| `SPACESHIP_VI_MODE_COLOR` | `white` | Color of Vi-mode section |
+
+You can temporarily enable or disable vi-mode with handy functions (just execute them in terminal as any other regular command):
+
+| Function | Meaning |
+| :------- | ------- |
+| `spaceship_vi_mode_enable` | Enable vi-mode for current terminal session |
+| `spaceship_vi_mode_disable` | Disable vi-mode for current terminal session |
+
+**Note:** For oh-my-zsh users with vi-mode plugin enabled: Add `export RPS1="%{$reset_color%}"` before `source $ZSH/oh-my-zsh.sh` in `.zshrc` to disable default `<<<` NORMAL mode indicator in right prompt.
+
+### Jobs (`jobs`)
+
+This section show only when there are active jobs in the background.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_JOBS_SHOW` | `true` | Show background jobs indicator  |
+| `SPACESHIP_JOBS_PREFIX` | `` | Prefix before the jobs indicator |
+| `SPACESHIP_JOBS_SUFFIX` | ` ` | Suffix after the jobs indicator |
+| `SPACESHIP_JOBS_SYMBOL` | `✦` | Character to be shown when jobs are hiding |
+| `SPACESHIP_JOBS_COLOR` | `blue` | Color of background jobs section |
+
+### Exit code (`exit_code`)
+
+Disabled as default. Set `SPACESHIP_EXIT_CODE_SHOW` to `true` in your `.zshrc`, if you need to show exit code of last command.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_EXIT_CODE_SHOW` | `false` | Show exit code of last command |
+| `SPACESHIP_EXIT_CODE_PREFIX` | `` | Prefix before exit code section |
+| `SPACESHIP_EXIT_CODE_SUFFIX` | ` ` | Suffix after exit code section |
+| `SPACESHIP_EXIT_CODE_SYMBOL` | `✘` | Character to be shown before exit code |
+| `SPACESHIP_EXIT_CODE_COLOR` | `red` | Color of exit code section |
+
+### Java (`java`)
+
+Shows Java version.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_JAVA_SHOW` | `true` | Show current Java version or not |
+| `SPACESHIP_JAVA_PREFIX` | `on ` | Prefix before the Java section |
+| `SPACESHIP_JAVA_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Java section |
+| `SPACESHIP_JAVA_SYMBOL` | `☕` | Character to be shown before Java version |
+| `SPACESHIP_JAVA_COLOR` | `magenta` | Color of Java section |
+
+### Example
+
+Here is all options which may be changed. Copy this to your `~/.zshrc` to make it easy to change.
+
+**Warning!:** These overridden variables should be placed _after_ the theme in your `.zshrc` file.
+
+```zsh
+# ORDER
+SPACESHIP_PROMPT_ORDER=(
+  time
+  user
+  host
+  dir
+  git
+  hg
+  package
+  node
+  ruby
+  elixir
+  xcode
+  swift
+  golang
+  php
+  rust
+  java
+  julia
+  docker
+  aws
+  venv
+  conda
+  pyenv
+  dotnet
+  ember
+  kubecontext
+  battery
+  exec_time
+  line_sep
+  vi_mode
+  jobs
+  exit_code
+  char
+)
+
+# PROMPT
+SPACESHIP_PROMPT_SYMBOL="➜"
+SPACESHIP_PROMPT_ADD_NEWLINE=true
+SPACESHIP_PROMPT_SEPARATE_LINE=true
+SPACESHIP_PROMPT_PREFIXES_SHOW=true
+SPACESHIP_PROMPT_SUFFIXES_SHOW=true
+SPACESHIP_PROMPT_DEFAULT_PREFIX="via "
+SPACESHIP_PROMPT_DEFAULT_SUFFIX=" "
+
+# CHAR
+SPACESHIP_CHAR_SUCCESS_COLOR="green"
+SPACESHIP_CHAR_FAILURE_COLOR="red"
+SPACESHIP_CHAR_SECONDARY_COLOR="yellow"
+
+# TIME
+SPACESHIP_TIME_SHOW=false
+SPACESHIP_TIME_PREFIX="at "
+SPACESHIP_TIME_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_TIME_FORMAT=false
+SPACESHIP_TIME_12HR=false
+SPACESHIP_TIME_COLOR="yellow"
+
+# EXECUTION TIME
+SPACESHIP_EXEC_TIME_SHOW=true
+SPACESHIP_EXEC_TIME_PREFIX="took "
+SPACESHIP_EXEC_TIME_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_EXEC_TIME_COLOR="yellow"
+SPACESHIP_EXEC_TIME_THRESHOLD=5000
+SPACESHIP_EXEC_TIME_MS=false
+
+# USER
+SPACESHIP_USER_SHOW=true
+SPACESHIP_USER_PREFIX="with "
+SPACESHIP_USER_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_USER_COLOR="yellow"
+SPACESHIP_USER_COLOR_ROOT="red"
+
+# HOST
+SPACESHIP_HOST_SHOW=true
+SPACESHIP_HOST_PREFIX="at "
+SPACESHIP_HOST_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_HOST_COLOR="green"
+
+# DIR
+SPACESHIP_DIR_SHOW=true
+SPACESHIP_DIR_PREFIX="in "
+SPACESHIP_DIR_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_DIR_TRUNC=3
+SPACESHIP_DIR_COLOR="cyan"
+
+# GIT
+SPACESHIP_GIT_SHOW=true
+SPACESHIP_GIT_PREFIX="on "
+SPACESHIP_GIT_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_GIT_SYMBOL=" "
+# GIT BRANCH
+SPACESHIP_GIT_BRANCH_SHOW=true
+SPACESHIP_GIT_BRANCH_PREFIX="$SPACESHIP_GIT_SYMBOL"
+SPACESHIP_GIT_BRANCH_SUFFIX=""
+SPACESHIP_GIT_BRANCH_COLOR="magenta"
+# GIT STATUS
+SPACESHIP_GIT_STATUS_SHOW=true
+SPACESHIP_GIT_STATUS_PREFIX=" ["
+SPACESHIP_GIT_STATUS_SUFFIX="]"
+SPACESHIP_GIT_STATUS_COLOR="red"
+SPACESHIP_GIT_STATUS_UNTRACKED="?"
+SPACESHIP_GIT_STATUS_ADDED="+"
+SPACESHIP_GIT_STATUS_MODIFIED="!"
+SPACESHIP_GIT_STATUS_RENAMED="»"
+SPACESHIP_GIT_STATUS_DELETED="✘"
+SPACESHIP_GIT_STATUS_STASHED="$"
+SPACESHIP_GIT_STATUS_UNMERGED="="
+SPACESHIP_GIT_STATUS_AHEAD="⇡"
+SPACESHIP_GIT_STATUS_BEHIND="⇣"
+SPACESHIP_GIT_STATUS_DIVERGED="⇕"
+
+# HG
+SPACESHIP_HG_SHOW=true
+SPACESHIP_HG_PREFIX="on "
+SPACESHIP_HG_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_HG_SYMBOL="☿ "
+# HG BRANCH
+SPACESHIP_HG_BRANCH_SHOW=true
+SPACESHIP_HG_BRANCH_PREFIX="$SPACESHIP_HG_SYMBOL"
+SPACESHIP_HG_BRANCH_SUFFIX=""
+SPACESHIP_HG_BRANCH_COLOR="magenta"
+# HG STATUS
+SPACESHIP_HG_STATUS_SHOW=true
+SPACESHIP_HG_STATUS_PREFIX="["
+SPACESHIP_HG_STATUS_SUFFIX="]"
+SPACESHIP_HG_STATUS_COLOR="red"
+SPACESHIP_HG_STATUS_UNTRACKED="?"
+SPACESHIP_HG_STATUS_ADDED="+"
+SPACESHIP_HG_STATUS_MODIFIED="!"
+SPACESHIP_HG_STATUS_DELETED="✘"
+
+# PACKAGE
+SPACESHIP_PACKAGE_SHOW=true
+SPACESHIP_PACKAGE_PREFIX="is "
+SPACESHIP_PACKAGE_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_PACKAGE_SYMBOL="📦 "
+SPACESHIP_PACKAGE_COLOR="red"
+
+# NODE
+SPACESHIP_NODE_SHOW=true
+SPACESHIP_NODE_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_NODE_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_NODE_SYMBOL="⬢ "
+SPACESHIP_NODE_DEFAULT_VERSION=""
+SPACESHIP_NODE_COLOR="green"
+
+# RUBY
+SPACESHIP_RUBY_SHOW=true
+SPACESHIP_RUBY_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_RUBY_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_RUBY_SYMBOL="💎 "
+SPACESHIP_RUBY_COLOR="red"
+
+# ELIXIR
+SPACESHIP_ELIXIR_SHOW=true
+SPACESHIP_ELIXIR_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_ELIXIR_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_ELIXIR_SYMBOL="💧 "
+SPACESHIP_ELIXIR_DEFAULT_VERSION=""
+SPACESHIP_ELIXIR_COLOR="magenta"
+
+# XCODE
+SPACESHIP_XCODE_SHOW_LOCAL=true
+SPACESHIP_XCODE_SHOW_GLOBAL=false
+SPACESHIP_XCODE_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_XCODE_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_XCODE_SYMBOL="🛠 "
+SPACESHIP_XCODE_COLOR="blue"
+
+# SWIFT
+SPACESHIP_SWIFT_SHOW_LOCAL=true
+SPACESHIP_SWIFT_SHOW_GLOBAL=false
+SPACESHIP_SWIFT_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_SWIFT_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_SWIFT_SYMBOL="🐦 "
+SPACESHIP_SWIFT_COLOR="yellow"
+
+# GOLANG
+SPACESHIP_GOLANG_SHOW=true
+SPACESHIP_GOLANG_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_GOLANG_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_GOLANG_SYMBOL="🐹 "
+SPACESHIP_GOLANG_COLOR="cyan"
+
+# PHP
+SPACESHIP_PHP_SHOW=true
+SPACESHIP_PHP_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_PHP_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_PHP_SYMBOL="🐘 "
+SPACESHIP_PHP_COLOR="blue"
+
+# RUST
+SPACESHIP_RUST_SHOW=true
+SPACESHIP_RUST_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_RUST_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_RUST_SYMBOL="𝗥 "
+SPACESHIP_RUST_COLOR="red"
+
+# JAVA
+SPACESHIP_JAVA_SHOW=true
+SPACESHIP_JAVA_PREFIX="on "
+SPACESHIP_JAVA_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_JAVA_SYMBOL="☕ "
+SPACESHIP_JAVA_COLOR="magenta"
+
+# JULIA
+SPACESHIP_JULIA_SHOW=true
+SPACESHIP_JULIA_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_JULIA_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_JULIA_SYMBOL="ஃ "
+SPACESHIP_JULIA_COLOR="green"
+
+# DOCKER
+SPACESHIP_DOCKER_SHOW=true
+SPACESHIP_DOCKER_PREFIX="on "
+SPACESHIP_DOCKER_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_DOCKER_SYMBOL="🐳 "
+SPACESHIP_DOCKER_COLOR="cyan"
+
+# Amazon Web Services (AWS)
+SPACESHIP_AWS_SHOW=true
+SPACESHIP_AWS_PREFIX="using "
+SPACESHIP_AWS_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_AWS_SYMBOL="☁️ "
+SPACESHIP_AWS_COLOR="208"
+
+# VENV
+SPACESHIP_VENV_SHOW=true
+SPACESHIP_VENV_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_VENV_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_VENV_COLOR="blue"
+
+# CONDA
+SPACESHIP_CONDA_SHOW=true
+SPACESHIP_CONDA_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_CONDA_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_CONDA_SYMBOL="🅒 "
+SPACESHIP_CONDA_COLOR="blue"
+
+# PYENV
+SPACESHIP_PYENV_SHOW=true
+SPACESHIP_PYENV_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_PYENV_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_PYENV_SYMBOL="🐍 "
+SPACESHIP_PYENV_COLOR="yellow"
+
+# DOTNET
+SPACESHIP_DOTNET_SHOW=true
+SPACESHIP_DOTNET_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_DOTNET_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_DOTNET_SYMBOL=".NET "
+SPACESHIP_DOTNET_COLOR="128"
+
+# EMBER
+SPACESHIP_EMBER_SHOW=true
+SPACESHIP_EMBER_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_EMBER_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_EMBER_SYMBOL="🐹 "
+SPACESHIP_EMBER_COLOR="210"
+
+# KUBECONTEXT
+SPACESHIP_KUBECONTEXT_SHOW=true
+SPACESHIP_KUBECONTEXT_PREFIX="at "
+SPACESHIP_KUBECONTEXT_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_KUBECONTEXT_SYMBOL="☸️ "
+SPACESHIP_KUBECONTEXT_COLOR="cyan"
+
+# BATTERY
+SPACESHIP_BATTERY_SHOW=true
+SPACESHIP_BATTERY_ALWAYS_SHOW=false
+SPACESHIP_BATTERY_PREFIX=""
+SPACESHIP_BATTERY_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_BATTERY_CHARGING_SYMBOL="⇡"
+SPACESHIP_BATTERY_DISCHARGING_SYMBOL="⇣"
+SPACESHIP_BATTERY_FULL_SYMBOL="•"
+SPACESHIP_BATTERY_THRESHOLD=10
+
+# VI_MODE
+SPACESHIP_VI_MODE_SHOW=true
+SPACESHIP_VI_MODE_PREFIX=""
+SPACESHIP_VI_MODE_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_VI_MODE_INSERT="[I]"
+SPACESHIP_VI_MODE_NORMAL="[N]"
+SPACESHIP_VI_MODE_COLOR="white"
+
+# JOBS
+SPACESHIP_JOBS_SHOW="true"
+SPACESHIP_JOBS_PREFIX=""
+SPACESHIP_JOBS_SUFFIX=" "
+SPACESHIP_JOBS_SYMBOL="✦"
+SPACESHIP_JOBS_COLOR="blue"
+
+# EXIT CODE
+SPACESHIP_EXIT_CODE_SHOW=false
+SPACESHIP_EXIT_CODE_PREFIX="("
+SPACESHIP_EXIT_CODE_SUFFIX=") "
+SPACESHIP_EXIT_CODE_SYMBOl="✘ "
+SPACESHIP_EXIT_CODE_COLOR="red"
+```
+>>>>>>> Support of java, 3.0 port of #139 @anton-johansson
 
 ## Donate
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ SPACESHIP_PROMPT_ORDER=(
   haskell       # Haskell Stack section
   java          # Java section
   gradle        # Gradle section
+  maven         # Maven section
   julia         # Julia section
   docker        # Docker section
   aws           # Amazon Web Services section
@@ -427,6 +428,18 @@ Shows Gradle version.
 | `SPACESHIP_GRADLE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Gradle section |
 | `SPACESHIP_GRADLE_SYMBOL` | `⬡` | Character to be shown before Gradle version |
 | `SPACESHIP_GRADLE_COLOR` | `green` | Color of Gradle section |
+
+### Maven (`maven` )
+
+Shows Maven version.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_MAVEN_SHOW` | `true` | Show current Maven version or not |
+| `SPACESHIP_MAVEN_PREFIX` | `on ` | Prefix before the Maven section |
+| `SPACESHIP_MAVEN_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Maven section |
+| `SPACESHIP_MAVEN_SYMBOL` | `𝑚` | Character to be shown before Maven version |
+| `SPACESHIP_MAVEN_COLOR` | `yellow` | Color of Maven section |
 
 ### Example
 
@@ -647,6 +660,13 @@ SPACESHIP_GRADLE_PREFIX="on "
 SPACESHIP_GRADLE_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
 SPACESHIP_GRADLE_SYMBOL="⬡ "
 SPACESHIP_GRADLE_COLOR="green"
+
+# MAVEN
+SPACESHIP_MAVEN_SHOW=true
+SPACESHIP_MAVEN_PREFIX="on "
+SPACESHIP_MAVEN_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_MAVEN_SYMBOL="𝑚 "
+SPACESHIP_MAVEN_COLOR="yellow"
 
 # JULIA
 SPACESHIP_JULIA_SHOW=true

--- a/sections/gradle.zsh
+++ b/sections/gradle.zsh
@@ -1,0 +1,36 @@
+#
+# Gradle
+#
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+: ${SPACESHIP_GRADLE_SHOW=true}
+: ${SPACESHIP_GRADLE_PREFIX="on "}
+: ${SPACESHIP_GRADLE_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}
+: ${SPACESHIP_GRADLE_SYMBOL="⬡ "}
+: ${SPACESHIP_GRADLE_COLOR="green"}
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show current Gradle version
+spaceship_gradle() {
+  [[ $SPACESHIP_GRADLE_SHOW == false ]] && return
+
+  # Check if local ./gradlew first or system gradle is available
+  { spaceship::exists ./gradlew && gradle_command="./gradlew" } || { spaceship::exists gradle && gradle_command=gradle } || return
+
+  # Check if gradle project
+  [[ -f build.gradle || -f build.gradle.kts ]] || return
+
+  local gradle_version=$($gradle_command --version 2>&1 | grep '^Gradle' | awk -F ' ' '{print $2}')
+
+  spaceship::section \
+    "$SPACESHIP_GRADLE_COLOR" \
+    "$SPACESHIP_GRADLE_PREFIX" \
+    "${SPACESHIP_GRADLE_SYMBOL}v${gradle_version}" \
+    "$SPACESHIP_GRADLE_SUFFIX"
+}

--- a/sections/java.zsh
+++ b/sections/java.zsh
@@ -1,0 +1,36 @@
+#
+# Java
+#
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+: ${SPACESHIP_JAVA_SHOW=true}
+: ${SPACESHIP_JAVA_PREFIX="on "}
+: ${SPACESHIP_JAVA_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}
+: ${SPACESHIP_JAVA_SYMBOL="☕ "}
+: ${SPACESHIP_JAVA_COLOR="green"}
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show current Java version.
+spaceship_java() {
+  [[ $SPACESHIP_JAVA_SHOW == false ]] && return
+
+  # Check if java is available
+  spaceship::exists java || return
+
+  # Check if maven or gradle project
+  [[ -f pom.xml || -f build.gradle || -f build.gradle.kts ]] || return
+
+  local java_version=$(java -version 2>&1 | grep '^java version ' | awk -F '"' '{print $2}')
+
+  spaceship::section \
+    "$SPACESHIP_JAVA_COLOR" \
+    "$SPACESHIP_JAVA_PREFIX" \
+    "${SPACESHIP_JAVA_SYMBOL}v${java_version}" \
+    "$SPACESHIP_JAVA_SUFFIX"
+}

--- a/sections/maven.zsh
+++ b/sections/maven.zsh
@@ -1,0 +1,36 @@
+#
+# Maven
+#
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+: ${SPACESHIP_MAVEN_SHOW=true}
+: ${SPACESHIP_MAVEN_PREFIX="on "}
+: ${SPACESHIP_MAVEN_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}
+: ${SPACESHIP_MAVEN_SYMBOL="𝑚 "}
+: ${SPACESHIP_MAVEN_COLOR="yellow"}
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show current Maven version
+spaceship_maven() {
+  [[ $SPACESHIP_MAVEN_SHOW == false ]] && return
+
+  # Check if local ./mvnw first or system mvn is available
+  { spaceship::exists ./mvnw && mvn_command="./mvnw" } || { spaceship::exists mvn && mvn_command=mvn } || return
+
+  # Check if maven project
+  [[ -f pom.xml ]] || return
+
+  local mvn_version=$($mvn_command --version 2>&1 | grep '^Apache Maven' | awk -F ' ' '{print $3}')
+
+  spaceship::section \
+    "$SPACESHIP_MAVEN_COLOR" \
+    "$SPACESHIP_MAVEN_PREFIX" \
+    "${SPACESHIP_MAVEN_SYMBOL}v${mvn_version}" \
+    "$SPACESHIP_MAVEN_SUFFIX"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -58,6 +58,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     haskell       # Haskell Stack section
     java          # Java section
     gradle        # Gradle section
+    maven         # Maven section
     julia         # Julia section
     docker        # Docker section
     aws           # Amazon Web Services section

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -56,6 +56,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     php           # PHP section
     rust          # Rust section
     haskell       # Haskell Stack section
+    java          # Java section
     julia         # Julia section
     docker        # Docker section
     aws           # Amazon Web Services section

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -57,6 +57,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     rust          # Rust section
     haskell       # Haskell Stack section
     java          # Java section
+    gradle        # Gradle section
     julia         # Julia section
     docker        # Docker section
     aws           # Amazon Web Services section


### PR DESCRIPTION
_Targets 3.0_

----------------------------------------------------------------

This fixes #138 for spaceship 3.0. I needed them at some point in v3.0 so I developed them without waiting for #139 to be completed.

Also I added maven and gradle support. I am not a fan of the speed of gradle or maven at this time though ; I'm not sure on how to improve this in a reliable way though.

Also I didn't find great _icons_ for gradle and maven, so used respectively `⬡` and `𝑚`. Gradle uses an elephant now, but it kinda collides with PHP, and `⬡` looks like their previous logo.