### PR TITLE
Show tags and remotes in git_branch section

### DIFF
--- a/lib/hooks.zsh
+++ b/lib/hooks.zsh
@@ -21,3 +21,9 @@ spaceship_exec_time_precmd_hook() {
   SPACESHIP_EXEC_TIME_duration=$(( $SPACESHIP_EXEC_TIME_stop - $SPACESHIP_EXEC_TIME_start ))
   unset SPACESHIP_EXEC_TIME_start
 }
+
+# vcs_info hook
+spaceship_exec_vcs_info_precmd_hook() {
+  [[ $SPACESHIP_GIT_BRANCH_SHOW == false ]] && return
+  vcs_info
+}

--- a/sections/git_branch.zsh
+++ b/sections/git_branch.zsh
@@ -19,14 +19,11 @@ SPACESHIP_GIT_BRANCH_COLOR="${SPACESHIP_GIT_BRANCH_COLOR="magenta"}"
 spaceship_git_branch() {
   [[ $SPACESHIP_GIT_BRANCH_SHOW == false ]] && return
 
-  spaceship::is_git || return
+  local git_current_branch="$vcs_info_msg_0_"
+  [[ -z "$git_current_branch" ]] && return
 
-  local ref=$(command git symbolic-ref --quiet HEAD 2> /dev/null) ret=$?
-  if [[ $ret != 0 ]]; then
-    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
-  fi
-
-  local git_current_branch=${ref#refs/heads/}
+  git_current_branch="${git_current_branch#heads/}"
+  git_current_branch="${git_current_branch/.../}"
 
   spaceship::section \
     "$SPACESHIP_GIT_BRANCH_COLOR" \

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -179,6 +179,7 @@ spaceship_ps2() {
 # Runs once when user opens a terminal
 # All preparation before drawing prompt should be done here
 prompt_spaceship_setup() {
+  autoload -Uz vcs_info
   autoload -Uz add-zsh-hook
 
   # This variable is a magic variable used when loading themes with zsh's prompt
@@ -195,6 +196,11 @@ prompt_spaceship_setup() {
 
   # Disable python virtualenv environment prompt prefix
   VIRTUAL_ENV_DISABLE_PROMPT=true
+
+  # Configure vcs_info helper for potential use in the future
+  add-zsh-hook precmd spaceship_exec_vcs_info_precmd_hook
+  zstyle ':vcs_info:*' enable git
+  zstyle ':vcs_info:git*' formats '%b'
 
   # Expose Spaceship to environment variables
   PROMPT='$(spaceship_prompt)'


### PR DESCRIPTION
A better way to improve git_branch section, shows remote branches as well as tags. Replaces #291.

Screenshots:

![image](https://user-images.githubusercontent.com/1177900/34435369-53cafb32-ec8d-11e7-9cb0-7f2dad2e1414.png)

By the way, `vcs_info` is quite powerful and potentially can be used to also improve/simplify all other `git*` and `hg*` sections, if anyone is interested 🙂