### PR TITLE
Update README to include prezto-contrib instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Done. This command should link `spaceship.zsh` as `prompt_spaceship_setup` to yo
 
 ### [prezto]
 
-`prezto` follows vanilla Zsh prompt setup. Just use [npm](#npm) or follow instructions in [manual](https://github.com/denysdovhan/spaceship-prompt#manual) installation.
+* Follow https://github.com/belak/prezto-contrib#usage to clone `prezto-contrib` to the proper location.
+* Enable the `contrib-prompt` module (before the `prompt` module).
+* Set `zstyle ':prezto:module:prompt' theme 'spaceship'` in your `.zpreztorc`.
 
 ### [antigen]
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Done. This command should link `spaceship.zsh` as `prompt_spaceship_setup` to yo
 
 ### [prezto]
 
-* Follow https://github.com/belak/prezto-contrib#usage to clone `prezto-contrib` to the proper location.
+* Follow [prezto-contrib#usage](https://github.com/belak/prezto-contrib#usage) to clone `prezto-contrib` to the proper location.
 * Enable the `contrib-prompt` module (before the `prompt` module).
 * Set `zstyle ':prezto:module:prompt' theme 'spaceship'` in your `.zpreztorc`.
 


### PR DESCRIPTION
#### Description

When I saw that 3.0 had been released, I updated prezto-contrib to include the latest tagged version (3.0.1 at the time of writing this)

I've included basic instructions for enabling the prezto-contrib repo and the relevant module, though I'd be happy to clarify anything if there are any questions.
