### PR TITLE
Update licence year as range

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 [Denys Dovhan](http://denysdovhan.com)
+Copyright (c) 2016-2018 [Denys Dovhan](https://denysdovhan.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
From https://www.gnu.org/licenses/gpl-howto.html,

> copyright notice should include the year in which you finished
preparing the release

> For software with several releases over multiple years, it's okay to
use a range (“2008-2010”)

Replacing #295.
