### PR TITLE
Add direct installation instructions for oh-my-zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,17 @@ Done. This command should link `spaceship.zsh` as `prompt_spaceship_setup` to yo
 
 ### [oh-my-zsh]
 
-* Set `ZSH_THEME=""` in your `.zshrc`
-* Follow instructions in [manual](https://github.com/denysdovhan/spaceship-prompt#manual) installation.
+* Clone this repo:
+  ```zsh
+  git clone https://github.com/denysdovhan/spaceship-prompt.git "$ZSH_CUSTOM/themes/spaceship-prompt"
+  ```
+
+* Symlink `spaceship.zsh-theme` to your oh-my-zsh custom themes directory:
+  ```zsh
+  ln -s "$ZSH_CUSTOM/themes/spaceship-prompt/spaceship.zsh-theme" "$ZSH_CUSTOM/themes/spaceship.zsh-theme"
+  ```
+
+* Set `ZSH_THEME="spaceship"` in your `.zshrc`.
 
 ### [prezto]
 

--- a/README.md
+++ b/README.md
@@ -96,17 +96,19 @@ Done. This command should link `spaceship.zsh` as `prompt_spaceship_setup` to yo
 
 ### [oh-my-zsh]
 
-* Clone this repo:
-  ```zsh
-  git clone https://github.com/denysdovhan/spaceship-prompt.git "$ZSH_CUSTOM/themes/spaceship-prompt"
-  ```
+Clone this repo:
 
-* Symlink `spaceship.zsh-theme` to your oh-my-zsh custom themes directory:
-  ```zsh
-  ln -s "$ZSH_CUSTOM/themes/spaceship-prompt/spaceship.zsh-theme" "$ZSH_CUSTOM/themes/spaceship.zsh-theme"
-  ```
+```zsh
+git clone https://github.com/denysdovhan/spaceship-prompt.git "$ZSH_CUSTOM/themes/spaceship-prompt"
+```
 
-* Set `ZSH_THEME="spaceship"` in your `.zshrc`.
+Symlink `spaceship.zsh-theme` to your oh-my-zsh custom themes directory:
+
+```zsh
+ln -s "$ZSH_CUSTOM/themes/spaceship-prompt/spaceship.zsh-theme" "$ZSH_CUSTOM/themes/spaceship.zsh-theme"
+```
+
+Set `ZSH_THEME="spaceship"` in your `.zshrc`.
 
 ### [prezto]
 


### PR DESCRIPTION
This will load the theme via `source` instead of via `prompt`, but I think that is already done in some Zsh plugin managers like antigen anyhow.

Simple installation instructions for oh-my-zsh were removed in 3.0 probably when the prompt was split into multiple files, but it can still be installed using `ZSH_THEME` like shown.
