### PR TITLE
Upgrade Zsh requirement to 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can find more examples with different color schemes in [Screenshots](https:/
 
 For correct work you will first need:
 
-* [`zsh`](http://www.zsh.org/) (v5.0.6 or recent) must be installed.
+* [`zsh`](http://www.zsh.org/) (v5.1 or recent) must be installed.
 * [Powerline Font](https://github.com/powerline/fonts) must be installed and used in your terminal.
 
 ## Installing
@@ -215,7 +215,7 @@ MIT © [Denys Dovhan](http://denysdovhan.com)
 [npm-image]: https://img.shields.io/npm/v/spaceship-prompt.svg?style=flat-square
 
 [zsh-url]: http://zsh.org/
-[zsh-image]: https://img.shields.io/badge/zsh-%3E%3Dv5.0.6-777777.svg?style=flat-square
+[zsh-image]: https://img.shields.io/badge/zsh-%3E%3Dv5.1-777777.svg?style=flat-square
 
 [donate-readme]: https://github.com/denysdovhan/spaceship-prompt#donate
 [donate-card-url]: https://www.liqpay.com/en/checkout/380951100392


### PR DESCRIPTION
#### Description

Zsh added several [reserved words for builtins](https://git.io/vNu04) with 5.1. This causes issues with `spaceship::union`

#### Screenshot

![Zsh 5.0.8 union issue](https://user-images.githubusercontent.com/694940/35146822-7ff6f992-fd0c-11e7-92b9-2d8d34ce06b1.png)

Close #328 

cc: @nfischer 
