### PR TITLE
Added an option to show the entire hostname (%M) instead of the short one (%m)

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -119,7 +119,7 @@ Hostname is shown only when you're connected via SSH unless you change this beha
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_HOST_SHOW` | `true` | Show host section (`true`, `false` or `always`) |
-| `SPACESHIP_HOST_FULL` | `false` | Show full hostname section (`true`, `false`) |
+| `SPACESHIP_HOST_SHOW_FULL` | `false` | Show full hostname section (`true`, `false`) |
 | `SPACESHIP_HOST_PREFIX` | `at·` | Prefix before the connected SSH machine name |
 | `SPACESHIP_HOST_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the connected SSH machine name |
 | `SPACESHIP_HOST_COLOR` | `blue` | Color of host section |

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -119,6 +119,7 @@ Hostname is shown only when you're connected via SSH unless you change this beha
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_HOST_SHOW` | `true` | Show host section (`true`, `false` or `always`) |
+| `SPACESHIP_HOST_FULL` | `false` | Show full hostname section (`true`, `false`) |
 | `SPACESHIP_HOST_PREFIX` | `at·` | Prefix before the connected SSH machine name |
 | `SPACESHIP_HOST_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the connected SSH machine name |
 | `SPACESHIP_HOST_COLOR` | `blue` | Color of host section |

--- a/sections/host.zsh
+++ b/sections/host.zsh
@@ -22,7 +22,8 @@ spaceship_host() {
   [[ $SPACESHIP_HOST_SHOW == false ]] && return
 
   if [[ $SPACESHIP_HOST_SHOW == 'always' ]] || [[ -n $SSH_CONNECTION ]]; then
-    local host_color, host
+    local host_color
+    local host
 
     # Determination of what color should be used
     if [[ -n $SSH_CONNECTION ]]; then

--- a/sections/host.zsh
+++ b/sections/host.zsh
@@ -22,8 +22,7 @@ spaceship_host() {
   [[ $SPACESHIP_HOST_SHOW == false ]] && return
 
   if [[ $SPACESHIP_HOST_SHOW == 'always' ]] || [[ -n $SSH_CONNECTION ]]; then
-    local host_color
-    local host
+    local host_color, host
 
     # Determination of what color should be used
     if [[ -n $SSH_CONNECTION ]]; then

--- a/sections/host.zsh
+++ b/sections/host.zsh
@@ -22,8 +22,7 @@ spaceship_host() {
   [[ $SPACESHIP_HOST_SHOW == false ]] && return
 
   if [[ $SPACESHIP_HOST_SHOW == 'always' ]] || [[ -n $SSH_CONNECTION ]]; then
-    local host_color
-    local host
+    local host_color host
 
     # Determination of what color should be used
     if [[ -n $SSH_CONNECTION ]]; then

--- a/sections/host.zsh
+++ b/sections/host.zsh
@@ -7,7 +7,7 @@
 # ------------------------------------------------------------------------------
 
 SPACESHIP_HOST_SHOW="${SPACESHIP_HOST_SHOW=true}"
-SPACESHIP_HOST_SHOW_FULL="${SPACESHIP_HOST_SHOW_FULL=false}"
+SPACESHIP_HOST_FULL="${SPACESHIP_HOST_FULL=false}"
 SPACESHIP_HOST_PREFIX="${SPACESHIP_HOST_PREFIX="at "}"
 SPACESHIP_HOST_SUFFIX="${SPACESHIP_HOST_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_HOST_COLOR="${SPACESHIP_HOST_COLOR="blue"}"
@@ -32,7 +32,7 @@ spaceship_host() {
       host_color=$SPACESHIP_HOST_COLOR
     fi
 
-    if [[ $SPACESHIP_HOST_SHOW_FULL == true ]]; then
+    if [[ $SPACESHIP_HOST_FULL == true ]]; then
       zsh_expansion="%M"
     else
       zsh_expansion="%m"

--- a/sections/host.zsh
+++ b/sections/host.zsh
@@ -7,7 +7,7 @@
 # ------------------------------------------------------------------------------
 
 SPACESHIP_HOST_SHOW="${SPACESHIP_HOST_SHOW=true}"
-SPACESHIP_HOST_FULL="${SPACESHIP_HOST_FULL=false}"
+SPACESHIP_HOST_SHOW_FULL="${SPACESHIP_HOST_SHOW_FULL=false}"
 SPACESHIP_HOST_PREFIX="${SPACESHIP_HOST_PREFIX="at "}"
 SPACESHIP_HOST_SUFFIX="${SPACESHIP_HOST_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_HOST_COLOR="${SPACESHIP_HOST_COLOR="blue"}"
@@ -23,7 +23,7 @@ spaceship_host() {
 
   if [[ $SPACESHIP_HOST_SHOW == 'always' ]] || [[ -n $SSH_CONNECTION ]]; then
     local host_color
-    local zsh_expansion
+    local host
 
     # Determination of what color should be used
     if [[ -n $SSH_CONNECTION ]]; then
@@ -32,16 +32,16 @@ spaceship_host() {
       host_color=$SPACESHIP_HOST_COLOR
     fi
 
-    if [[ $SPACESHIP_HOST_FULL == true ]]; then
-      zsh_expansion="%M"
+    if [[ $SPACESHIP_HOST_SHOW_FULL == true ]]; then
+      host="%M"
     else
-      zsh_expansion="%m"
+      host="%m"
     fi
 
     spaceship::section \
       "$host_color" \
       "$SPACESHIP_HOST_PREFIX" \
-      "$zsh_expansion" \
+      "$host" \
       "$SPACESHIP_HOST_SUFFIX"
   fi
 }

--- a/sections/host.zsh
+++ b/sections/host.zsh
@@ -7,6 +7,7 @@
 # ------------------------------------------------------------------------------
 
 SPACESHIP_HOST_SHOW="${SPACESHIP_HOST_SHOW=true}"
+SPACESHIP_HOST_SHOW_FULL="${SPACESHIP_HOST_SHOW_FULL=false}"
 SPACESHIP_HOST_PREFIX="${SPACESHIP_HOST_PREFIX="at "}"
 SPACESHIP_HOST_SUFFIX="${SPACESHIP_HOST_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_HOST_COLOR="${SPACESHIP_HOST_COLOR="blue"}"
@@ -22,6 +23,7 @@ spaceship_host() {
 
   if [[ $SPACESHIP_HOST_SHOW == 'always' ]] || [[ -n $SSH_CONNECTION ]]; then
     local host_color
+    local zsh_expansion
 
     # Determination of what color should be used
     if [[ -n $SSH_CONNECTION ]]; then
@@ -30,10 +32,16 @@ spaceship_host() {
       host_color=$SPACESHIP_HOST_COLOR
     fi
 
+    if [[ $SPACESHIP_HOST_SHOW_FULL == true ]]; then
+      zsh_expansion="%M"
+    else
+      zsh_expansion="%m"
+    fi
+
     spaceship::section \
       "$host_color" \
       "$SPACESHIP_HOST_PREFIX" \
-      '%m' \
+      "$zsh_expansion" \
       "$SPACESHIP_HOST_SUFFIX"
   fi
 }


### PR DESCRIPTION
**Description**
Added option SPACESHIP_HOST_SHOW_FULL to enable displaying the full hostname of the machine, rather than its short representaion. Copy&paste from zsh docs:
```
%M
The full machine hostname.

%m
The hostname up to the first ‘.’. An integer may follow the ‘%’ to specify how many components of the hostname are desired. With a negative integer, trailing components of the hostname are shown.
```