### PR TITLE
Add k8s current namespace

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -460,7 +460,7 @@ Shows the active kubectl context.
 
 ### Kubectl namespace (`k8s_namespace`)
 
-Shows currnet kubectl namespace. This requires [jq](https://stedolan.github.io/jq/) to parse output from `kubectl`.
+Shows currnet kubectl namespace.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -40,7 +40,7 @@ SPACESHIP_PROMPT_ORDER=(
   pyenv         # Pyenv section
   dotnet        # .NET section
   ember         # Ember.js section
-  kubecontext   # Kubectl context section
+  k8s           # Kubctl section (kubecontext + k8s_namespace)
   exec_time     # Execution time
   line_sep      # Line break
   battery       # Battery level and status
@@ -436,6 +436,16 @@ Ember.js section is shown only in directories that contain a `ember-cli-build.js
 | `SPACESHIP_EMBER_SYMBOL` | `🐹·` | Character to be shown before Ember.js version |
 | `SPACESHIP_EMBER_COLOR` | `210` | Color of Ember.js section |
 
+### K8s (`k8s`)
+
+Shows both the active kubectl context (`kubecontext`) and namespace (`k8s_namespace`)
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_K8S_SHOW` | `true` | Show Both Kubectl context and namespace |
+| `SPACESHIP_K8S_PREFIX` | `at·` | Prefix before k8s section |
+| `SPACESHIP_K8S_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after k8s section |
+
 ### Kubectl context (`kubecontext`)
 
 Shows the active kubectl context.
@@ -443,10 +453,22 @@ Shows the active kubectl context.
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_KUBECONTEXT_SHOW` | `true` | Current Kubectl context section |
-| `SPACESHIP_KUBECONTEXT_PREFIX` | `at·` | Prefix before Kubectl context section |
-| `SPACESHIP_KUBECONTEXT_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Kubectl context section |
+| `SPACESHIP_KUBECONTEXT_PREFIX` | ` ` | Prefix before Kubectl context section |
+| `SPACESHIP_KUBECONTEXT_SUFFIX` | ` ` | Suffix after Kubectl context section |
 | `SPACESHIP_KUBECONTEXT_SYMBOL` | `☸️·` | Character to be shown before Kubectl context |
 | `SPACESHIP_KUBECONTEXT_COLOR` | `cyan` | Color of Kubectl context section |
+
+### Kubectl namespace (`k8s_namespace`)
+
+Shows currnet kubectl namespace. This requires [jq](https://stedolan.github.io/jq/) to parse output from `kubectl`.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+`SPACESHIP_K8S_NAMESPACE_SHOW` | `true` | Show namespace section |
+`SPACESHIP_K8S_NAMESPACE_PREFIX` | ` ` | Prefix before Kubectl namespace section |
+`SPACESHIP_K8S_NAMESPACE_SEPARATOR` | `/` | Separator between context and namespace |
+`SPACESHIP_K8S_NAMESPACE_SUFFIX` | ` ` | Suffix after Kubectl namespace section |
+`SPACESHIP_K8S_NAMESPACE_COLOR` | `cyan` | Color of Kubectl namespace section |
 
 ### Execution time (`exec_time`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaceship-prompt",
-  "version": "3.0.3",
+  "version": "3.0.2",
   "description": "A Zsh prompt for Astronauts.",
   "files": [
     "lib",

--- a/sections/k8s.zsh
+++ b/sections/k8s.zsh
@@ -1,0 +1,39 @@
+#
+# k8s - Show k8s context and namespace
+#
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_K8S_SHOW="${SPACESHIP_K8S_SHOW=true}"
+SPACESHIP_K8S_PREFIX="${SPACESHIP_K8S_PREFIX="at "}"
+SPACESHIP_K8S_SUFFIX="${SPACESHIP_K8S_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+
+# ------------------------------------------------------------------------------
+# Dependencies
+# ------------------------------------------------------------------------------
+
+source "$SPACESHIP_ROOT/sections/kubecontext.zsh"
+source "$SPACESHIP_ROOT/sections/k8s_namespace.zsh"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show both k8s context and namespace:
+#   spaceship_kubecontext
+#   spaceship_k8s_namespace
+spaceship_k8s() {
+  [[ $SPACESHIP_K8S_SHOW == false ]] && return
+
+  local k8s_context="$(spaceship_kubecontext)" k8s_namespace="$(spaceship_k8s_namespace)"
+
+  [[ -z $k8s_context ]] && return
+
+  spaceship::section \
+    'white' \
+    "$SPACESHIP_K8S_PREFIX" \
+    "${k8s_context}${k8s_namespace}" \
+    "$SPACESHIP_K8S_SUFFIX"
+}

--- a/sections/k8s_namespace.zsh
+++ b/sections/k8s_namespace.zsh
@@ -1,0 +1,44 @@
+#
+# Kubernetes Namespace
+#
+# Kubernetes is an open-source system for deployment, scaling,
+# and management of containerized applications.
+# Link: https://kubernetes.io/
+#
+# This section requires jq https://stedolan.github.io/jq/ to be installed.
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_K8S_NAMESPACE_SHOW="${SPACESHIP_K8S_NAMESPACE_SHOW=true}"
+SPACESHIP_K8S_NAMESPACE_PREFIX="${SPACESHIP_K8S_NAMESPACE_PREFIX=""}"
+SPACESHIP_K8S_NAMESPACE_SEPARATOR="${SPACESHIP_K8S_NAMESPACE_SEPARATOR="/"}"
+SPACESHIP_K8S_NAMESPACE_SUFFIX="${SPACESHIP_K8S_NAMESPACE_SUFFIX=""}"
+SPACESHIP_K8S_NAMESPACE_COLOR="${SPACESHIP_K8S_NAMESPACE_COLOR="cyan"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show current context in kubectl
+spaceship_k8s_namespace() {
+  [[ $SPACESHIP_KUBE_NAMESPACE_SHOW == false ]] && return
+
+  spaceship::exists kubectl || return
+  spaceship::exists jq || return
+
+  local kube_context=$(kubectl config current-context 2>/dev/null)
+
+  [[ -z $kube_context ]] && return
+
+  local kube_namespace=$(kubectl config view -o json 2>/dev/null | jq -e -r ".contexts[] | select(.name==\"${kube_context}\") | .context.namespace | select (.!=null)" || echo "default")
+
+  [[ -z $kube_namespace ]] && return
+
+  spaceship::section \
+    "${SPACESHIP_K8S_NAMESPACE_COLOR}" \
+    "${SPACESHIP_K8S_NAMESPACE_PREFIX}" \
+    "${SPACESHIP_K8S_NAMESPACE_SEPARATOR}${kube_namespace}" \
+    "${SPACESHIP_K8S_NAMESPACE_SUFFIX}"
+}

--- a/sections/k8s_namespace.zsh
+++ b/sections/k8s_namespace.zsh
@@ -5,7 +5,6 @@
 # and management of containerized applications.
 # Link: https://kubernetes.io/
 #
-# This section requires jq https://stedolan.github.io/jq/ to be installed.
 
 # ------------------------------------------------------------------------------
 # Configuration
@@ -26,15 +25,16 @@ spaceship_k8s_namespace() {
   [[ $SPACESHIP_KUBE_NAMESPACE_SHOW == false ]] && return
 
   spaceship::exists kubectl || return
-  spaceship::exists jq || return
 
   local kube_context=$(kubectl config current-context 2>/dev/null)
 
   [[ -z $kube_context ]] && return
 
-  local kube_namespace=$(kubectl config view -o json 2>/dev/null | jq -e -r ".contexts[] | select(.name==\"${kube_context}\") | .context.namespace | select (.!=null)" || echo "default")
+  local kube_namespace=$(kubectl config view -o jsonpath="{.contexts[?(@.name == \"${kube_context}\")].context.namespace}")
 
-  [[ -z $kube_namespace ]] && return
+  if [[ -z $kube_namespace ]]; then
+    kube_namespace="default"
+  fi
 
   spaceship::section \
     "${SPACESHIP_K8S_NAMESPACE_COLOR}" \

--- a/sections/kubecontext.zsh
+++ b/sections/kubecontext.zsh
@@ -1,5 +1,5 @@
 #
-#  Kubernetes (kubectl)
+#  Kubernetes context (kubectl)
 #
 # Kubernetes is an open-source system for deployment, scaling,
 # and management of containerized applications.
@@ -10,8 +10,8 @@
 # ------------------------------------------------------------------------------
 
 SPACESHIP_KUBECONTEXT_SHOW="${SPACESHIP_KUBECONTEXT_SHOW=true}"
-SPACESHIP_KUBECONTEXT_PREFIX="${SPACESHIP_KUBECONTEXT_PREFIX="at "}"
-SPACESHIP_KUBECONTEXT_SUFFIX="${SPACESHIP_KUBECONTEXT_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_KUBECONTEXT_PREFIX="${SPACESHIP_KUBECONTEXT_PREFIX=""}"
+SPACESHIP_KUBECONTEXT_SUFFIX="${SPACESHIP_KUBECONTEXT_SUFFIX=""}"
 SPACESHIP_KUBECONTEXT_SYMBOL="${SPACESHIP_KUBECONTEXT_SYMBOL="☸️ "}"
 SPACESHIP_KUBECONTEXT_COLOR="${SPACESHIP_KUBECONTEXT_COLOR="cyan"}"
 

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -64,7 +64,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     pyenv         # Pyenv section
     dotnet        # .NET section
     ember         # Ember.js section
-    kubecontext   # Kubectl context section
+    k8s           # Kubectl section (kubecontext + k8s_namespace)
     exec_time     # Execution time
     line_sep      # Line break
     battery       # Battery level and status


### PR DESCRIPTION
#### Description

Add support for kubernetes namespace in addition to current context, because I get distracted..._oh squirrel_...and forget what namespace I'm working in.

I tried to follow the pattern the git section uses for combining branch and status.

`k8s_namespace` does require `jq` to be installed. Unfortunately there's no easy `kubectl` command to just get the namespace. If you have to dump the config and if you have multiple contexts you can't just grep.

It does check for `jq` and `kubectl` and skips the namespace section if its not installed.

I left kubecontext and called the new sections k8s and k8s_namespace.  IMHO its better then kubenamespace, but I'd be happy to rename them or rename the kubecontext to make everything match.

Thanks for an awesome zsh theme.

#### Screenshot

![screenshot from 2018-01-24 19-38-34](https://user-images.githubusercontent.com/5324639/35366285-4066a828-013e-11e8-9b11-daa56c97a5e7.png)

I tweaked the color to `032` in the screenshot. Default is `cyan`
