### PR TITLE
Change order of loading hg subsections

### DIFF
--- a/sections/hg.zsh
+++ b/sections/hg.zsh
@@ -3,13 +3,6 @@
 #
 
 # ------------------------------------------------------------------------------
-# Dependencies
-# ------------------------------------------------------------------------------
-
-source "$SPACESHIP_ROOT/sections/hg_branch.zsh"
-source "$SPACESHIP_ROOT/sections/hg_status.zsh"
-
-# ------------------------------------------------------------------------------
 # Configuration
 # ------------------------------------------------------------------------------
 
@@ -17,6 +10,13 @@ SPACESHIP_HG_SHOW="${SPACESHIP_HG_SHOW=true}"
 SPACESHIP_HG_PREFIX="${SPACESHIP_HG_PREFIX="on "}"
 SPACESHIP_HG_SUFFIX="${SPACESHIP_HG_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_HG_SYMBOL="${SPACESHIP_HG_SYMBOL="☿ "}"
+
+# ------------------------------------------------------------------------------
+# Dependencies
+# ------------------------------------------------------------------------------
+
+source "$SPACESHIP_ROOT/sections/hg_branch.zsh"
+source "$SPACESHIP_ROOT/sections/hg_status.zsh"
 
 # ------------------------------------------------------------------------------
 # Section


### PR DESCRIPTION
Source `hg` subsections after variable definitions to pass variables to `hg_branch` and `hg_status`