### PR TITLE
Show hg bookmark instead of branch, When available

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Currently it shows:
   * `⇡` — ahead of remote branch;
   * `⇣` — behind of remote branch;
   * `⇕` — diverged chages.
-* Current Mercurial branch and rich repo status:
+* Current Mercurial bookmark/branch and rich repo status:
   * `?` — untracked changes;
   * `+` — uncommitted changes in the index;
   * `!` — unstaged changes;

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -191,6 +191,8 @@ Mercurial section is consists with `hg_branch` and `hg_status` subsections. It i
 
 #### Mercurial branch (`hg_branch`)
 
+Shows Mercurial bookmarks when available, Else shows Mercurial branch information.
+
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_HG_BRANCH_SHOW` | `true` | Show Mercurial branch subsection |

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -191,7 +191,7 @@ Mercurial section is consists with `hg_branch` and `hg_status` subsections. It i
 
 #### Mercurial branch (`hg_branch`)
 
-Shows Mercurial bookmarks when available, Else shows Mercurial branch information.
+Shows Mercurial bookmarks when available, otherwise shows Mercurial branch information.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |

--- a/sections/hg_branch.zsh
+++ b/sections/hg_branch.zsh
@@ -29,5 +29,5 @@ spaceship_hg_branch() {
 
   spaceship::section \
     "$SPACESHIP_HG_BRANCH_COLOR" \
-    "$SPACESHIP_HG_SYMBOL"$hg_info"$SPACESHIP_HG_BRANCH_SUFFIX"
+    "$SPACESHIP_HG_BRANCH_PREFIX"$hg_info"$SPACESHIP_HG_BRANCH_SUFFIX"
 }

--- a/sections/hg_branch.zsh
+++ b/sections/hg_branch.zsh
@@ -21,7 +21,13 @@ spaceship_hg_branch() {
 
   spaceship::is_hg || return
 
+  local hg_info=$(hg log -r . -T '{activebookmark}')
+
+  if [[ -z $hg_info ]]; then
+    hg_info=$(hg branch)
+  fi
+
   spaceship::section \
     "$SPACESHIP_HG_BRANCH_COLOR" \
-    "$SPACESHIP_HG_BRANCH_PREFIX"$(hg branch)"$SPACESHIP_HG_BRANCH_SUFFIX"
+    "$SPACESHIP_HG_SYMBOL"$hg_info"$SPACESHIP_HG_BRANCH_SUFFIX"
 }


### PR DESCRIPTION
#### Description

When updated to a mercurial bookmark from repository, Show the corresponding bookmark information and hide the current branch information. 

#### Screenshot

![hg bookmarks](https://i.imgur.com/dhotmRa.png)

Huge thanks to @davehunt for the suggestion and base command.  

Closes #213 
