### PR TITLE
Add note about git copied status indicator

### DIFF
--- a/sections/git_status.zsh
+++ b/sections/git_status.zsh
@@ -55,6 +55,7 @@ spaceship_git_status() {
   if $(echo "$INDEX" | command grep '^M[ MD] ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_MODIFIED$git_status"
   elif $(echo "$INDEX" | command grep '^[ MARC]M ' &> /dev/null); then
+    # Copied status 'C' is never available with `git status`, See #364
     git_status="$SPACESHIP_GIT_STATUS_MODIFIED$git_status"
   fi
 


### PR DESCRIPTION
On investigating #355, Found that git copied status `C` is very rare and would not be available with `git status --porcelain -b`. 

Currently it's available only through `git diff --find-copies` or the more expensive `git diff --find-copies-harder`. Also visible on using this options on `git log` command.

[1]: https://goo.gl/N7Zycc - Discussion on Git dev forum
[2]: https://stackoverflow.com/a/2673456/3451554
