### PR TITLE
Preserve whitespaces in battery/upower section

### DIFF
--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -52,8 +52,8 @@ spaceship_battery() {
     [[ -z $battery ]] && return
 
     battery_data=$(upower -i $battery)
-    battery_percent="$( echo $battery_data | grep percentage | awk '{print $2}' )"
-    battery_status="$( echo $battery_data | grep state | awk '{print $2}' )"
+    battery_percent="$( echo '$battery_data' | grep percentage | awk '{print $2}' )"
+    battery_status="$( echo '$battery_data' | grep state | awk '{print $2}' )"
   elif spaceship::exists acpi; then
     battery_data=$(acpi -b)
 

--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -52,8 +52,8 @@ spaceship_battery() {
     [[ -z $battery ]] && return
 
     battery_data=$(upower -i $battery)
-    battery_percent="$( echo '$battery_data' | grep percentage | awk '{print $2}' )"
-    battery_status="$( echo '$battery_data' | grep state | awk '{print $2}' )"
+    battery_percent="$( echo "$battery_data" | grep percentage | awk '{print $2}' )"
+    battery_status="$( echo "$battery_data" | grep state | awk '{print $2}' )"
   elif spaceship::exists acpi; then
     battery_data=$(acpi -b)
 


### PR DESCRIPTION
#### Description
This PR fix a small bug in the `battery.zsh` section preventing the correct display of the battery percentage and status when using `upower`.

Basically, the two variables were not quoted and therefore would not preserve the whitespaces necessary for the `awk` to correctly match on the second column.

Note: I only tested this on stock Fedora 27.