### PR TITLE
add installation instructions for arch linux (from user repository)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,19 +152,13 @@ zplug denysdovhan/spaceship-prompt, use:spaceship.zsh, from:github, as:theme
 
 #### Arch linux
 
-Install the latest master from the
-[AUR](https://aur.archlinux.org/packages/spaceship-prompt-git/):
+Install the latest master from the [AUR package
+`spaceship-prompt-git`](https://aur.archlinux.org/packages/spaceship-prompt-git/):
 
 ```
 git clone https://aur.archlinux.org/spaceship-prompt-git.git
 cd spaceship-prompt-git
 makepkg -si
-```
-
-Or using [pacaur]():
-
-```
-pacaur -S spaceship-prompt-git
 ```
 
 ### Manual

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ zplug denysdovhan/spaceship-prompt, use:spaceship.zsh, from:github, as:theme
 
 ### Linux package manager
 
-#### Arch linux
+#### Arch Linux
 
 Install the latest master from the [AUR package
 `spaceship-prompt-git`](https://aur.archlinux.org/packages/spaceship-prompt-git/):

--- a/README.md
+++ b/README.md
@@ -148,6 +148,25 @@ Use this command in your `.zshrc` to load Spaceship as prompt theme:
 zplug denysdovhan/spaceship-prompt, use:spaceship.zsh, from:github, as:theme
 ```
 
+### Linux package manager
+
+#### Arch linux
+
+Install the latest master from the
+[AUR](https://aur.archlinux.org/packages/spaceship-prompt-git/):
+
+```
+git clone https://aur.archlinux.org/spaceship-prompt-git.git
+cd spaceship-prompt-git
+makepkg -si
+```
+
+Or using [pacaur]():
+
+```
+pacaur -S spaceship-prompt-git
+```
+
 ### Manual
 
 If you have problems with approches above, follow these instructions:

--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ zplug denysdovhan/spaceship-prompt, use:spaceship.zsh, from:github, as:theme
 
 #### Arch Linux
 
-Install the latest master from the [AUR package
-`spaceship-prompt-git`](https://aur.archlinux.org/packages/spaceship-prompt-git/):
+Install the latest master from the AUR package [`spaceship-prompt-git`](https://aur.archlinux.org/packages/spaceship-prompt-git/):
 
 ```
 git clone https://aur.archlinux.org/spaceship-prompt-git.git


### PR DESCRIPTION
#### Description

This adds a pointer the README to the arch linux package spaceship-prompt-git along with instructions for installing it manually (should be familiar to an arch user).