### PR TITLE
fix bug: If git work-tree directory name has spaces, git section will fail and raise an error.

### DIFF
--- a/sections/dir.zsh
+++ b/sections/dir.zsh
@@ -26,7 +26,8 @@ spaceship_dir() {
   # Threat repo root as a top-level directory or not
   if [[ $SPACESHIP_DIR_TRUNC_REPO == true ]] && spaceship::is_git; then
     local git_root=$(git rev-parse --show-toplevel)
-    dir="$git_root:t${$(expr $(pwd) : "$git_root\(.*\)")}"
+    local subdir=$(expr "$(pwd)" : "$git_root\(.*\)")
+    dir="${git_root:t}${subdir}"
   else
     dir="%${SPACESHIP_DIR_TRUNC}~"
   fi


### PR DESCRIPTION
Always quote computed variables passed to `expr` to ensure this doesn't fail if directory names have spaces. 
ref: http://wiki.bash-hackers.org/scripting/newbie_traps#expanding_using_variables