### PR TITLE
Fix directory truncation in git repositories with symlinks in path

### DIFF
--- a/sections/dir.zsh
+++ b/sections/dir.zsh
@@ -26,7 +26,7 @@ spaceship_dir() {
   # Threat repo root as a top-level directory or not
   if [[ $SPACESHIP_DIR_TRUNC_REPO == true ]] && spaceship::is_git; then
     local git_root=$(git rev-parse --show-toplevel)
-    dir="$git_root:t${$(expr $(pwd) : "$git_root\(.*\)")}"
+    dir="$git_root:t${$(expr $(pwd -P) : "$git_root\(.*\)")}"
   else
     dir="%${SPACESHIP_DIR_TRUNC}~"
   fi


### PR DESCRIPTION
#### Description
When setting SPACESHIP_DIR_TRUNC to true, only the root of the repository was show if the path to the directory contained symlinks.
Adding the -P option to the pwd call (avoid all symlinks) fixes this.

In the example below, 'Projects' is the symlink.

#### Screenshot
Before:
![Before](https://drive.google.com/uc?id=1UTKqebVasJ9lX6hV2OuxO6MCdhaDhoVu)

After:
![After](https://drive.google.com/uc?id=1xJQShwAtcq81JNfaYa8Uvl-AWVbYQSId)

