### PR TITLE
Show complete go version instead of first two digits

### DIFF
--- a/sections/golang.zsh
+++ b/sections/golang.zsh
@@ -27,7 +27,7 @@ spaceship_golang() {
 
   spaceship::exists go || return
 
-  local go_version=$(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]')
+  local go_version=$(go version | awk '{print $3}' | sed 's/go//' )
 
   spaceship::section \
     "$SPACESHIP_GOLANG_COLOR" \


### PR DESCRIPTION
**Before**
![Broken go versoin](https://user-images.githubusercontent.com/10276208/36972745-43c9a070-2096-11e8-9a77-7228f718a120.png)


**After**
![Fixed go version](https://user-images.githubusercontent.com/10276208/36972749-4d070e0c-2096-11e8-9924-028c499f9c89.png)

PS : Looking for better ways avoiding two command calls.

Fix #386 
