### PR TITLE
Add kubernetes namespace to kubecontext

### DIFF
--- a/sections/kubecontext.zsh
+++ b/sections/kubecontext.zsh
@@ -29,9 +29,12 @@ spaceship_kubecontext() {
 
   [[ -z $kube_context ]] && return
 
+  local kube_namespace=$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"${kube_context}\")].context.namespace}" 2>/dev/null)
+
   spaceship::section \
     "$SPACESHIP_KUBECONTEXT_COLOR" \
     "$SPACESHIP_KUBECONTEXT_PREFIX" \
     "${SPACESHIP_KUBECONTEXT_SYMBOL}${kube_context}" \
+    " (${kube_namespace})" \
     "$SPACESHIP_KUBECONTEXT_SUFFIX"
 }


### PR DESCRIPTION
#### Description

Most of the time is useful to have an immediate overview of which namespace we are currently in. It probably makes sense to have it displayed.

It is probably not the best way of integrating it with the prompt, but i'm open for suggestions

#### Screenshot

Please, attach a screenshot, if possible.

![untitled](https://user-images.githubusercontent.com/3543138/37031423-f5cd29a6-213e-11e8-8783-b72fb072ae55.png)

