### PR TITLE
Escape comments while checking duplicate prompt installation

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -100,7 +100,7 @@ mkdir -p "$DEST"
 ln -sf "$SOURCE" "$DEST/prompt_spaceship_setup"
 
 # If 'prompt spaceship' is already present in .zshrc, then skip
-if grep -q "prompt spaceship" "$ZSHRC"; then
+if sed 's/#.*//' "$ZSHRC" | grep -q "prompt spaceship"; then
   warn "Spaceship is already present in .zshrc!"
   exit
 fi


### PR DESCRIPTION
Filter comments out to make installing smoothly.

#### Description

I commented some command somehow, but didn't rollback it back 😭 
