### PR TITLE
Automate GitBook build on push with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,17 @@ before_script:
   - zsh --version
 script:
   - scripts/tests.sh
+jobs:
+  include:
+    - stage: deploy gitbook
+      if: branch = master AND type = push
+      script:
+        - npm install --only=dev --ignore-scripts
+        - npm run docs:build
+      deploy:
+       provider: pages
+       skip-cleanup: true
+       github-token: $GITHUB_TOKEN
+       committer-from-gh: true
+       keep-history: true
+       local-dir: _book

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "docs:prepare": "gitbook install",
     "docs:icons": "cp logos/apple-touch-icon.png _book/gitbook/images/apple-touch-icon-precomposed-152.png && cp logos/favicon.ico _book/gitbook/images",
     "docs:serve": "npm run docs:prepare && gitbook serve .",
-    "docs:build": "npm run docs:prepare && gitbook build && npm run docs:icons",
-    "docs:publish": "gh-pages -d _book -m \"Updated at $(date +'%a, %d %b %Y, %T, %Z')\" --add",
-    "docs:deploy": "npm run docs:build && npm run docs:publish"
+    "docs:build": "npm run docs:prepare && gitbook build && npm run docs:icons"
   },
   "repository": {
     "type": "git",
@@ -40,7 +38,6 @@
   },
   "homepage": "https://github.com/denysdovhan/spaceship-prompt#readme",
   "devDependencies": {
-    "gh-pages": "^1.1.0",
     "gitbook-cli": "^2.3.2",
     "gitbook-plugin-anchorjs": "^1.1.1",
     "gitbook-plugin-edit-link": "^2.0.2",


### PR DESCRIPTION
Automate building of the accompanying `spaceship` GitBook doc at https://denysdovhan.com/spaceship-prompt. Few caveats,

- Deploying [requires personal access token](https://docs.travis-ci.com/user/deployment/pages/#Setting-the-GitHub-token) with `public_repo` access. 
- Travis CI does not have support for custom commit messages now. But, There is an open issue at https://github.com/travis-ci/travis-ci/issues/9287. 

Huge thanks to @matchai for the heads up with [`.travis.yml`](https://github.com/matchai/spacefish/blob/master/.travis.yml) on [`spacefish`](https://github.com/matchai/spacefish) repo.


Close #371 

