### PR TITLE
Fix dir truncation for .git repo and subdirs

### DIFF
--- a/sections/dir.zsh
+++ b/sections/dir.zsh
@@ -25,7 +25,7 @@ spaceship_dir() {
 
   # Threat repo root as a top-level directory or not
   if [[ $SPACESHIP_DIR_TRUNC_REPO == true ]] && spaceship::is_git; then
-    local git_root=$(git rev-parse --show-toplevel)
+    local git_root=${$(git rev-parse --absolute-git-dir):h}
     dir="$git_root:t${$(expr $(pwd -P) : "$git_root\(.*\)")}"
   else
     dir="%${SPACESHIP_DIR_TRUNC}~"


### PR DESCRIPTION
#### Before
![.git dir before](https://user-images.githubusercontent.com/10276208/37509012-89769370-291b-11e8-9727-726e0d830d68.png)

#### After
![.git dir after](https://user-images.githubusercontent.com/10276208/37509014-8aaf5556-291b-11e8-8562-c67e69fd379f.png)

Fix #388 
