### PR TITLE
Fix PHP version formatting

### DIFF
--- a/sections/php.zsh
+++ b/sections/php.zsh
@@ -32,6 +32,6 @@ spaceship_php() {
   spaceship::section \
     "$SPACESHIP_PHP_COLOR" \
     "$SPACESHIP_PHP_PREFIX" \
-    "${SPACESHIP_PHP_SYMBOL} v${php_version}" \
+    "${SPACESHIP_PHP_SYMBOL}v${php_version}" \
     "${SPACESHIP_PHP_SUFFIX}"
 }

--- a/sections/php.zsh
+++ b/sections/php.zsh
@@ -32,6 +32,6 @@ spaceship_php() {
   spaceship::section \
     "$SPACESHIP_PHP_COLOR" \
     "$SPACESHIP_PHP_PREFIX" \
-    "${SPACESHIP_PHP_SYMBOL}v${php_version}" \
+    "${SPACESHIP_PHP_SYMBOL} v${php_version}" \
     "${SPACESHIP_PHP_SUFFIX}"
 }

--- a/sections/php.zsh
+++ b/sections/php.zsh
@@ -27,7 +27,7 @@ spaceship_php() {
 
   spaceship::exists php || return
 
-  local php_version=$(php -v 2>&1 | grep --color=never -oe "^PHP\s*[0-9.]*" | awk '{print $2}')
+  local php_version=$(php -v 2>&1 | grep --color=never -oe "^PHP\s*[0-9.]\+" | awk '{print $2}')
 
   spaceship::section \
     "$SPACESHIP_PHP_COLOR" \


### PR DESCRIPTION
**Description**
There were two issues with PHP version formatting I found. First, more importantly, was that `PHP` substring itself was matched after `grep`ping `php -v`.  When I execute php -v, there are some warnings however, such as:
```
PHP Warning:  PHP Startup: Unable to load dynamic library 'pdo_pgsql' (tried: /usr/local/Cellar/php/7.2.3_3/lib/php/20170718/pdo_pgsql (dlopen(/usr/local/Cellar/php/7.2.3_3/lib/php/20170718/pdo_pgsql, 9): image not found), /usr/local/Cellar/php/7.2.3_3/lib/php/20170718/pdo_pgsql.so (dlopen(/usr/local/Cellar/php/7.2.3_3/lib/php/20170718/pdo_pgsql.so, 9): image not found)) in Unknown on line 0
```

These warnings are also matched, and then, `awk` prints out empty lines. I fixed the pattern so that the version number is not optional.

Also, I added a space before version number, so that it is more consistent (see Node version in the same screenshot).

**Screenshot**
Before:
![image](https://user-images.githubusercontent.com/16063548/38237419-72f8619a-3727-11e8-8bf7-183c654fae74.png)

After:
![image](https://user-images.githubusercontent.com/16063548/38237430-7a982066-3727-11e8-99aa-2fef90679969.png)
