### PR TITLE
Use --show-toplevel to trunc repo dir path

### DIFF
--- a/sections/dir.zsh
+++ b/sections/dir.zsh
@@ -25,7 +25,7 @@ spaceship_dir() {
 
   # Threat repo root as a top-level directory or not
   if [[ $SPACESHIP_DIR_TRUNC_REPO == true ]] && spaceship::is_git; then
-    local git_root=${$(git rev-parse --absolute-git-dir):h}
+    local git_root=$(git rev-parse --show-toplevel)
     dir="$git_root:t${$(expr $(pwd -P) : "$git_root\(.*\)")}"
   else
     dir="%${SPACESHIP_DIR_TRUNC}~"


### PR DESCRIPTION

* Revet 18ed984: Handling of .git and its subdirectories in with
`--absolute-git-dir`.

* `--abolute-git-dir` was introduced with git v2.13.0-rc0, released on Apr
20, 2017. This is still relatively new and many operating systems don't
ship or support this version of git officially in their systems.
Depending on this breaks prompt for this users.

* 18ed984 also breaks handling of submodules.

Fix #412 
Close #415 
Reverts #398  
