### PR TITLE
Fix directory truncation inside .git dir

### DIFF
--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -21,7 +21,7 @@ spaceship::defined() {
 # USAGE:
 #   spaceship::is_git
 spaceship::is_git() {
-  command git rev-parse --is-inside-work-tree &>/dev/null
+  [[ $(command git rev-parse --is-inside-work-tree 2>/dev/null) == true ]]
 }
 
 # Check if the current directory is in a Mercurial repository.

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -21,6 +21,7 @@ spaceship::defined() {
 # USAGE:
 #   spaceship::is_git
 spaceship::is_git() {
+  # See https://git.io/fp8Pa for related discussion
   [[ $(command git rev-parse --is-inside-work-tree 2>/dev/null) == true ]]
 }
 


### PR DESCRIPTION
#### Description
Apparently the behavior of `git rev-parse --is-inside-work-tree` is:
1. If outside any git repo, exit with an error.
2. If inside a git repo, print "true".
3. If inside a git repo but outside the work tree (e.g. git dir), print "false".

(The first might actually be a bug...)

Fixes #388 (again)
Revert PR of the original fix which causes issues: https://github.com/denysdovhan/spaceship-prompt/pull/416

cc @salmanulfarzy 