### PR TITLE
modify declaration of dir variable in sections/dir

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -52,8 +52,16 @@ spaceship_foobar() {
   # http://zsh.sourceforge.net/Doc/Release/Expansion.html
   [[ -f foobar.conf || -n *.foo(#qN^/) || -n *.bar(#qN^/) ]] || return
 
-  # Retrieve foobar status and save it to variable
-  local foobar_status=$(foobar status)
+  # Use quotes around unassigned local variables to prevent
+  # getting replaced by global aliases
+  # http://zsh.sourceforge.net/Doc/Release/Shell-Grammar.html#Aliasing
+  local 'foobar_status'
+
+  if [[ $SOME_CONDITION ]]; then
+    foobar_status=$foobar baz)
+  else
+    foobar_status=$(foobar foo)
+  fi
 
   # Display foobar section
   spaceship::section \

--- a/docs/API.md
+++ b/docs/API.md
@@ -58,7 +58,7 @@ spaceship_foobar() {
   local 'foobar_status'
 
   if [[ $SOME_CONDITION ]]; then
-    foobar_status=$foobar baz)
+    foobar_status=$(foobar baz)
   else
     foobar_status=$(foobar foo)
   fi

--- a/sections/char.zsh
+++ b/sections/char.zsh
@@ -20,7 +20,7 @@ SPACESHIP_CHAR_COLOR_SECONDARY="${SPACESHIP_CHAR_COLOR_SECONDARY="yellow"}"
 # Paint $PROMPT_SYMBOL in red if previous command was fail and
 # paint in green if everything was OK.
 spaceship_char() {
-  local color
+  local 'color'
 
   if [[ $RETVAL -eq 0 ]]; then
     color="$SPACESHIP_CHAR_COLOR_SUCCESS"

--- a/sections/dir.zsh
+++ b/sections/dir.zsh
@@ -21,7 +21,7 @@ SPACESHIP_DIR_COLOR="${SPACESHIP_DIR_COLOR="cyan"}"
 spaceship_dir() {
   [[ $SPACESHIP_DIR_SHOW == false ]] && return
 
-  local dir
+  local dir=""
 
   # Threat repo root as a top-level directory or not
   if [[ $SPACESHIP_DIR_TRUNC_REPO == true ]] && spaceship::is_git; then

--- a/sections/dir.zsh
+++ b/sections/dir.zsh
@@ -21,6 +21,8 @@ SPACESHIP_DIR_COLOR="${SPACESHIP_DIR_COLOR="cyan"}"
 spaceship_dir() {
   [[ $SPACESHIP_DIR_SHOW == false ]] && return
 
+  # Use quotes around unassigned local variables to prevent
+  # getting replaced by global aliases
   local 'dir'
 
   # Threat repo root as a top-level directory or not

--- a/sections/dir.zsh
+++ b/sections/dir.zsh
@@ -21,8 +21,6 @@ SPACESHIP_DIR_COLOR="${SPACESHIP_DIR_COLOR="cyan"}"
 spaceship_dir() {
   [[ $SPACESHIP_DIR_SHOW == false ]] && return
 
-  # Use quotes around unassigned local variables to prevent
-  # getting replaced by global aliases
   local 'dir'
 
   # Threat repo root as a top-level directory or not

--- a/sections/dir.zsh
+++ b/sections/dir.zsh
@@ -21,7 +21,7 @@ SPACESHIP_DIR_COLOR="${SPACESHIP_DIR_COLOR="cyan"}"
 spaceship_dir() {
   [[ $SPACESHIP_DIR_SHOW == false ]] && return
 
-  local dir=""
+  local 'dir'
 
   # Threat repo root as a top-level directory or not
   if [[ $SPACESHIP_DIR_TRUNC_REPO == true ]] && spaceship::is_git; then

--- a/sections/elixir.zsh
+++ b/sections/elixir.zsh
@@ -26,7 +26,7 @@ spaceship_elixir() {
   # Show versions only for Elixir-specific folders
   [[ -f mix.exs || -n *.ex(#qN^/) || -n *.exs(#qN^/) ]] || return
 
-  local elixir_version
+  local 'elixir_version'
 
   if spaceship::exists kiex; then
     elixir_version="${ELIXIR_VERSION}"

--- a/sections/node.zsh
+++ b/sections/node.zsh
@@ -26,7 +26,7 @@ spaceship_node() {
   # Show NODE status only for JS-specific folders
   [[ -f package.json || -d node_modules || -n *.js(#qN^/) ]] || return
 
-  local node_version
+  local 'node_version'
 
   if spaceship::exists nvm; then
     node_version=$(nvm current 2>/dev/null)

--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -25,7 +25,7 @@ spaceship_ruby() {
   # Show versions only for Ruby-specific folders
   [[ -f Gemfile || -f Rakefile || -n *.rb(#qN^/) ]] || return
 
-  local ruby_version
+  local 'ruby_version'
 
   if spaceship::exists rvm-prompt; then
     ruby_version=$(rvm-prompt i v g)

--- a/sections/swift.zsh
+++ b/sections/swift.zsh
@@ -23,7 +23,7 @@ SPACESHIP_SWIFT_COLOR="${SPACESHIP_SWIFT_COLOR="yellow"}"
 spaceship_swift() {
   spaceship::exists swiftenv || return
 
-  local swift_version
+  local 'swift_version'
 
   if [[ $SPACESHIP_SWIFT_SHOW_GLOBAL == true ]] ; then
     swift_version=$(swiftenv version | sed 's/ .*//')

--- a/sections/time.zsh
+++ b/sections/time.zsh
@@ -21,7 +21,7 @@ SPACESHIP_TIME_COLOR="${SPACESHIP_TIME_COLOR="yellow"}"
 spaceship_time() {
   [[ $SPACESHIP_TIME_SHOW == false ]] && return
 
-  local time_str
+  local 'time_str'
 
   if [[ $SPACESHIP_TIME_FORMAT != false ]]; then
     time_str="${SPACESHIP_TIME_FORMAT}"

--- a/sections/user.zsh
+++ b/sections/user.zsh
@@ -33,7 +33,7 @@ spaceship_user() {
   || [[ $UID == 0 ]] \
   || [[ $SPACESHIP_USER_SHOW == true && -n $SSH_CONNECTION ]]
   then
-    local user_color
+    local 'user_color'
 
     if [[ $USER == 'root' ]]; then
       user_color=$SPACESHIP_USER_COLOR_ROOT

--- a/sections/venv.zsh
+++ b/sections/venv.zsh
@@ -27,7 +27,7 @@ spaceship_venv() {
   # Check if the current directory running via Virtualenv
   [ -n "$VIRTUAL_ENV" ] || return
 
-  local venv
+  local 'venv'
 
   if [[ "${SPACESHIP_VENV_GENERIC_NAMES[(i)$VIRTUAL_ENV:t]}" -le \
         "${#SPACESHIP_VENV_GENERIC_NAMES}" ]]

--- a/sections/xcode.zsh
+++ b/sections/xcode.zsh
@@ -23,7 +23,7 @@ SPACESHIP_XCODE_COLOR="${SPACESHIP_XCODE_COLOR="blue"}"
 spaceship_xcode() {
   spaceship::exists xcenv || return
 
-  local xcode_path
+  local 'xcode_path'
 
   if [[ $SPACESHIP_SWIFT_SHOW_GLOBAL == true ]] ; then
     xcode_path=$(xcenv version | sed 's/ .*//')


### PR DESCRIPTION
#### Description

potential fix for #420, feel free to close this PR if a better solution can be found

Fixes the issue by explicitly assigning the variable to prevent it from accidentally expanding the dir variable if there is a shell alias assigned to it.


Fix #420 
