### PR TITLE
Split issue templates to multiple templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,32 +1,11 @@
 <!--
+Thanks for filing an issue 😄 !
+
 BEFORE SUBMITTING NEW ISSUE, PLEASE, READ THE TROUBLESHOOTING PAGE!
 
 https://github.com/denysdovhan/spaceship-prompt/blob/master/docs/Troubleshooting.md
 
-If your issue is not addressed by the troubleshooting page and there are no duplicates, please, fill in the following details so that we can help you!
+Check the other issue templates if you are trying to submit a bug report, feature request, or question
+Search open/closed issues before submitting since someone might have asked the same thing before!
 -->
 
-#### Issue
-
-Describe your issue, steps to reproduce, additional information…
-
-#### Screenshot
-
-Provide a screenshot that shows your issue
-
-![screenshot](url)
-
-# Environment
-
-**Spaceship version:** <version> (use `echo $SPACESHIP_VERSION`)
-**Zsh version:** <version>
-**Zsh framework:** <None/oh-my-zsh/prezto/etc>
-**Zsh plugin manager:** <None/antigen/zplug/etc>
-**Terminal emulator:** <iTerm/Hyper/Terminator/etc>
-**Operating system:** <macOS/Windows/Linux>
-
-#### Relevant `.zshrc`
-
-```zsh
-# your configuration here
-```

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -1,0 +1,36 @@
+---
+name: 🐛 Bug Report
+about: If something isn't working as expected 🤔.
+
+---
+
+**Current Behavior**
+A clear and concise description of the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+#### Relevant `Zsh` Configuration (`.zshrc`)
+
+```zsh
+# Your configuration here
+```
+
+#### Environment
+
+**Spaceship version:** <version> (use `echo $SPACESHIP_VERSION`)
+**Zsh version:** <version>
+**Zsh framework:** <None/oh-my-zsh/prezto/etc>
+**Zsh plugin manager:** <None/antigen/zplug/etc>
+**Terminal emulator:** <iTerm/Hyper/Terminator/etc>
+**Operating system:** <macOS/Windows/Linux>
+
+#### Screenshot
+
+Provide a screenshot that shows your issue
+
+![screenshot](url)
+
+**Possible Solution**
+<!--- Only if you have suggestions on a fix/reason for the bug -->
+

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -7,6 +7,17 @@ about: I have a suggestion (and might want to implement myself 🙂)!
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I have an issue when [...]
 
+**Is your feature request related to new section on prompt? Then consider the following questions**
+
+- Will it clutter the prompt ?
+- Is it worth to be aware of it ?
+- Will it slow down the prompt ?
+
+<!--
+For more information on above points, See our contributing guidelines.
+https://github.com/denysdovhan/spaceship-prompt/blob/master/CONTRIBUTING.md#sections
+-->
+
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen. Add any considered drawbacks.
 
@@ -16,3 +27,4 @@ A clear and concise description of any alternative solutions or features you've 
 **Documentation, Adoption**
 If you can, explain how users will be able to use this and possibly write out a version the docs.
 Maybe a screenshot ?
+

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -1,0 +1,18 @@
+---
+name: 🚀 Feature Request
+about: I have a suggestion (and might want to implement myself 🙂)!
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I have an issue when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen. Add any considered drawbacks.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Documentation, Adoption**
+If you can, explain how users will be able to use this and possibly write out a version the docs.
+Maybe a screenshot ?

--- a/.github/ISSUE_TEMPLATE/Support_Question.md
+++ b/.github/ISSUE_TEMPLATE/Support_Question.md
@@ -1,0 +1,14 @@
+---
+name: 🤗 Support Question
+about: If you have a question 💬 about configuring prompt
+
+---
+
+<!--
+If you've trouble configuring `spaceship-prompt` on your machine, Feel free to ask.
+Make sure you're not asking duplicate question by searching on the issues lists.
+
+Also read our TROUBLESHOOTING page for commonly encountered problems,
+
+https://github.com/denysdovhan/spaceship-prompt/blob/master/docs/Troubleshooting.md
+-->


### PR DESCRIPTION
Separate issue templates depending on the scenario. This might be an overkill, Still wanted to know what others opinion on this.

Heavily copied from babel. 

![multiple issue templates](https://user-images.githubusercontent.com/10276208/39634054-5fe36230-4fd7-11e8-9669-49482dd7be04.png)
