### PR TITLE
Change `grep --colour` to `grep --color`

### DIFF
--- a/sections/julia.zsh
+++ b/sections/julia.zsh
@@ -27,7 +27,7 @@ spaceship_julia() {
 
   spaceship::exists julia || return
 
-  local julia_version=$(julia --version | grep --colour=never -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]')
+  local julia_version=$(julia --version | grep --color=never -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]')
 
   spaceship::section \
     "$SPACESHIP_JULIA_COLOR" \

--- a/sections/rust.zsh
+++ b/sections/rust.zsh
@@ -27,7 +27,7 @@ spaceship_rust() {
 
   spaceship::exists rustc || return
 
-  local rust_version=$(rustc --version | grep --colour=never -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]')
+  local rust_version=$(rustc --version | grep --color=never -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]')
 
   spaceship::section \
     "$SPACESHIP_RUST_COLOR" \


### PR DESCRIPTION
#### Description

The `grep` command aliases `--colour` to the American English `--color`, however tools designed to be command line compatible with `grep` do not always implement this alias. Specifically, [ripgrep](https://github.com/BurntSushi/ripgrep) does not support `--colour`.

#### Reproduction

**.zshrc**
```zsh
alias grep='nocorrect rg -S'
```

```zsh
% npm install -g spaceship-prompt
% prompt spaceship
% cargo new foo
% cd foo
error: Found argument '--colour' which wasn't expected, or isn't valid in this context
	Did you mean --color?

USAGE:

    rg [OPTIONS] PATTERN [PATH ...]
    rg [OPTIONS] [-e PATTERN ...] [-f FILE ...] [PATH ...]
    rg [OPTIONS] --files [PATH ...]
    rg [OPTIONS] --type-list

For more information try --help
% 
```

#### Screenshot

![screenshot](https://www.dropbox.com/s/l53gu3btnyrq2n6/screenshot_rakenodiax_grep_color.png)
