### PR TITLE
add minikube status conditional rendering and minikube profile

### DIFF
--- a/sections/kubecontext.zsh
+++ b/sections/kubecontext.zsh
@@ -31,6 +31,22 @@ spaceship_kubecontext() {
 
   [[ -z $kube_context ]] && return
 
+  if [[ $kube_context == 'minikube' ]] && spaceship::exists minikube ; then
+
+    local mk_status_text=$(minikube status --format '{{.MinikubeStatus}}' 2>/dev/null)
+    local mk_status_return=$?
+    [[ -z $mk_status_text || $mk_status_text == 'Stopped' ]] && return
+
+    if [[ $mk_status_return -ne 0 ]]; then
+      $kube_context+='[!]'
+    fi
+
+    local mk_profile=${$(minikube config get profile 2>/dev/null):-minikube}
+    if [[ ${mk_profile} != 'minikube' ]]; then
+      kube_context+="(${mk_profile})"
+    fi
+  fi
+
   spaceship::section \
     "$SPACESHIP_KUBECONTEXT_COLOR" \
     "$SPACESHIP_KUBECONTEXT_PREFIX" \


### PR DESCRIPTION
#### Description

Previously, if the kubernetes context was set to minikube, it would always show up even when minikube wasn't even running. This added a lot of noise to the prompt.

This PR makes it so that the kubecontext is skipped if it's minikube but it's not running. It also adds a minikube status check, `[!]` if there are are errors, and shows the minikube profile if it is not set to the default.

Unfortunately, this does slow down the prompt, although only in this particular context - it doesn't affect the rendering time when the kubernetes context isn't set. It might be worth waiting for #307 .

#### Screenshot

<img width="551" alt="screen shot 2018-05-21 at 11 52 28" src="https://user-images.githubusercontent.com/891202/40316882-b2f77ccc-5ced-11e8-9e6d-fae46c7e2a30.png">

