### PR TITLE
Added new git section to see current commit SHA

### DIFF
--- a/sections/git.zsh
+++ b/sections/git.zsh
@@ -16,6 +16,7 @@ SPACESHIP_GIT_SYMBOL="${SPACESHIP_GIT_SYMBOL=" "}"
 # ------------------------------------------------------------------------------
 
 source "$SPACESHIP_ROOT/sections/git_branch.zsh"
+source "$SPACESHIP_ROOT/sections/git_commit.zsh"
 source "$SPACESHIP_ROOT/sections/git_status.zsh"
 
 # ------------------------------------------------------------------------------
@@ -28,13 +29,13 @@ source "$SPACESHIP_ROOT/sections/git_status.zsh"
 spaceship_git() {
   [[ $SPACESHIP_GIT_SHOW == false ]] && return
 
-  local git_branch="$(spaceship_git_branch)" git_status="$(spaceship_git_status)"
+  local git_branch="$(spaceship_git_branch)" git_commit="$(spaceship_git_commit)" git_status="$(spaceship_git_status)"
 
   [[ -z $git_branch ]] && return
 
   spaceship::section \
     'white' \
     "$SPACESHIP_GIT_PREFIX" \
-    "${git_branch}${git_status}" \
+    "${git_branch}${git_commit}${git_status}" \
     "$SPACESHIP_GIT_SUFFIX"
 }

--- a/sections/git_commit.zsh
+++ b/sections/git_commit.zsh
@@ -1,0 +1,28 @@
+#
+# Git commit
+#
+# Show current git commit SHA
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_GIT_COMMIT_SHOW="${SPACESHIP_GIT_COMMIT_SHOW=true}"
+SPACESHIP_GIT_COMMIT_PREFIX="${SPACESHIP_GIT_COMMIT_PREFIX=" at "}"
+SPACESHIP_GIT_COMMIT_SUFFIX="${SPACESHIP_GIT_COMMIT_SUFFIX=""}"
+SPACESHIP_GIT_COMMIT_COLOR="${SPACESHIP_GIT_COMMIT_COLOR="magenta"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+spaceship_git_commit() {
+  [[ $SPACESHIP_GIT_COMMIT_SHOW == false ]] && return
+
+  local git_current_commit="$(git_prompt_short_sha)"
+  [[ -z "$git_current_commit" ]] && return
+
+  spaceship::section \
+    "$SPACESHIP_GIT_COMMIT_COLOR" \
+    "$SPACESHIP_GIT_COMMIT_PREFIX${git_current_commit}$SPACESHIP_GIT_COMMIT_SUFFIX"
+}


### PR DESCRIPTION
#### Description

Add a new git section called **commit** to show current git commit SHA and get more information about local repository status.

#### Screenshot

<img width="1263" alt="screen shot 2018-05-22 at 21 18 45" src="https://user-images.githubusercontent.com/879123/40385087-d243cfea-5e05-11e8-8866-e0ba7eb2adf3.png">

