### PR TITLE
Added option to hide NodeJS status on HOME dir

### DIFF
--- a/sections/node.zsh
+++ b/sections/node.zsh
@@ -9,6 +9,7 @@
 # ------------------------------------------------------------------------------
 
 SPACESHIP_NODE_SHOW="${SPACESHIP_NODE_SHOW=true}"
+SPACESHIP_NODE_SHOW_IN_HOME="${SPACESHIP_NODE_SHOW_IN_HOME=true}"
 SPACESHIP_NODE_PREFIX="${SPACESHIP_NODE_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
 SPACESHIP_NODE_SUFFIX="${SPACESHIP_NODE_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_NODE_SYMBOL="${SPACESHIP_NODE_SYMBOL="⬢ "}"
@@ -22,6 +23,9 @@ SPACESHIP_NODE_COLOR="${SPACESHIP_NODE_COLOR="green"}"
 # Show current version of node, exception system.
 spaceship_node() {
   [[ $SPACESHIP_NODE_SHOW == false ]] && return
+
+  # Hide NODE status on home if option is set
+  [[ $SPACESHIP_NODE_SHOW_IN_HOME == true || ($PWD != $HOME) ]] || return
 
   # Show NODE status only for JS-specific folders
   [[ -f package.json || -d node_modules || -n *.js(#qN^/) ]] || return


### PR DESCRIPTION
#### Description

NodeJS automatically keeps `node_modules` directory in $HOME directory. This ends up with the terminal showing NodeJS status similar to "via ⬢ v6.10.3" on a default prompt.  #167  This issue can't be resolved even by symlinking. To fix this, an option was added to check if the current directory is home and if it is, hide the node version info. Then an option toggle variable was added which is usable from ~/.zshrc. 

#### Screenshot

Before
![screenshot](https://i.imgur.com/NCZyJMj.png)

After
![screenshot](https://i.imgur.com/ib6gHcc.png)