### PR TITLE
Use of command directive to avoid possible user aliases

### DIFF
--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -38,36 +38,36 @@ spaceship_battery() {
   local battery_data battery_percent battery_status battery_color
 
   if spaceship::exists pmset; then
-    battery_data=$(pmset -g batt)
+    battery_data=$( command pmset -g batt )
 
     # Return if no internal battery
-    [[ -z $(echo $battery_data | grep "InternalBattery") ]] && return
+    [[ -z $( command echo $battery_data | command grep "InternalBattery" ) ]] && return
 
-    battery_percent="$( echo $battery_data | grep -oE '[0-9]{1,3}%' )"
-    battery_status="$( echo $battery_data | awk -F '; *' 'NR==2 { print $2 }' )"
+    battery_percent="$( command echo $battery_data | command grep -oE '[0-9]{1,3}%' )"
+    battery_status="$( command echo $battery_data | command awk -F '; *' 'NR==2 { print $2 }' )"
   elif spaceship::exists upower; then
-    local battery=$(command upower -e | grep battery | head -1)
+    local battery=$( command upower -e | command grep battery | command head -1 )
 
     # Return if no battery
     [[ -z $battery ]] && return
 
-    battery_data=$(upower -i $battery)
-    battery_percent="$( echo "$battery_data" | grep percentage | awk '{print $2}' )"
-    battery_status="$( echo "$battery_data" | grep state | awk '{print $2}' )"
+    battery_data=$( command upower -i $battery )
+    battery_percent="$( command echo "$battery_data" | command grep percentage | command awk '{print $2}' )"
+    battery_status="$( command echo "$battery_data" | command grep state | command awk '{print $2}' )"
   elif spaceship::exists acpi; then
-    battery_data=$(acpi -b)
+    battery_data=$( command acpi -b )
 
     # Return if no battery
     [[ -z $battery_data ]] && return
 
-    battery_percent="$( echo $battery_data | awk '{print $4}' )"
-    battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
+    battery_percent="$( command echo $battery_data | command awk '{print $4}' )"
+    battery_status="$( command echo $battery_data | command awk '{print tolower($3)}' )"
   else
     return
   fi
 
   # Remove trailing % and symbols for comparison
-  battery_percent="$(echo $battery_percent | tr -d '%[,;]')"
+  battery_percent="$( command echo $battery_percent | command tr -d '%[,;]' )"
 
   # Change color based on battery percentage
   if [[ $battery_percent == 100 || $battery_status =~ "(charged|full)" ]]; then

--- a/sections/dir.zsh
+++ b/sections/dir.zsh
@@ -25,8 +25,8 @@ spaceship_dir() {
 
   # Threat repo root as a top-level directory or not
   if [[ $SPACESHIP_DIR_TRUNC_REPO == true ]] && spaceship::is_git; then
-    local git_root=$(git rev-parse --show-toplevel)
-    dir="$git_root:t${$(expr $(pwd -P) : "$git_root\(.*\)")}"
+    local git_root=$( command git rev-parse --show-toplevel )
+    dir="$git_root:t${$( command expr $( command pwd -P ) : "$git_root\(.*\)" )}"
   else
     dir="%${SPACESHIP_DIR_TRUNC}~"
   fi

--- a/sections/docker.zsh
+++ b/sections/docker.zsh
@@ -28,7 +28,7 @@ spaceship_docker() {
   [[ -f $COMPOSE_FILE || -f Dockerfile || -f docker-compose.yml ]] || return
 
   # if docker daemon isn't running you'll get an error saying it can't connect
-  local docker_version=$(docker version -f "{{.Server.Version}}" 2>/dev/null)
+  local docker_version=$( command docker version -f "{{.Server.Version}}" 2>/dev/null )
   [[ -z $docker_version ]] && return
 
   if [[ -n $DOCKER_MACHINE_NAME ]]; then

--- a/sections/dotnet.zsh
+++ b/sections/dotnet.zsh
@@ -31,7 +31,7 @@ spaceship_dotnet() {
 
   # dotnet-cli automatically handles SDK pinning (specified in a global.json file)
   # therefore, this already returns the expected version for the current directory
-  local dotnet_version=$(dotnet --version 2>/dev/null)
+  local dotnet_version=$( command dotnet --version 2>/dev/null )
 
   spaceship::section \
     "$SPACESHIP_DOTNET_COLOR" \

--- a/sections/elixir.zsh
+++ b/sections/elixir.zsh
@@ -31,12 +31,12 @@ spaceship_elixir() {
   if spaceship::exists kiex; then
     elixir_version="${ELIXIR_VERSION}"
   elif spaceship::exists exenv; then
-    elixir_version=$(exenv version-name)
+    elixir_version=$( command exenv version-name )
   fi
 
   if [[ $elixir_version == "" ]]; then
     spaceship::exists elixir || return
-    elixir_version=$(elixir -v 2>/dev/null | grep "Elixir" --color=never | cut -d ' ' -f 2)
+    elixir_version=$( command elixir -v 2>/dev/null | command grep "Elixir" --color=never | command cut -d ' ' -f 2 )
   fi
 
   [[ $elixir_version == "system" ]] && return

--- a/sections/ember.zsh
+++ b/sections/ember.zsh
@@ -25,7 +25,7 @@ spaceship_ember() {
   # Show EMBER status only for folders w/ ember-cli-build.js files
   [[ -f ember-cli-build.js && -f node_modules/ember-cli/package.json ]] || return
 
-  local ember_version=$(grep '"version":' ./node_modules/ember-cli/package.json | cut -d\" -f4)
+  local ember_version=$( command grep '"version":' ./node_modules/ember-cli/package.json | command cut -d\" -f4 )
   [[ $ember_version == "system" || $ember_version == "ember" ]] && return
 
   spaceship::section \

--- a/sections/git_status.zsh
+++ b/sections/git_status.zsh
@@ -37,64 +37,64 @@ spaceship_git_status() {
 
   local INDEX git_status=""
 
-  INDEX=$(command git status --porcelain -b 2> /dev/null)
+  INDEX=$( command git status --porcelain -b 2> /dev/null )
 
   # Check for untracked files
-  if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
+  if $( command echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null ); then
     git_status="$SPACESHIP_GIT_STATUS_UNTRACKED$git_status"
   fi
 
   # Check for staged files
-  if $(echo "$INDEX" | command grep '^A[ MDAU] ' &> /dev/null); then
+  if $( command echo "$INDEX" | command grep '^A[ MDAU] ' &> /dev/null ); then
     git_status="$SPACESHIP_GIT_STATUS_ADDED$git_status"
-  elif $(echo "$INDEX" | command grep '^M[ MD] ' &> /dev/null); then
+  elif $( command echo "$INDEX" | command grep '^M[ MD] ' &> /dev/null ); then
     git_status="$SPACESHIP_GIT_STATUS_ADDED$git_status"
-  elif $(echo "$INDEX" | command grep '^UA' &> /dev/null); then
+  elif $( command echo "$INDEX" | command grep '^UA' &> /dev/null ); then
     git_status="$SPACESHIP_GIT_STATUS_ADDED$git_status"
   fi
 
   # Check for modified files
-  if $(echo "$INDEX" | command grep '^[ MARC]M ' &> /dev/null); then
+  if $( command echo "$INDEX" | command grep '^[ MARC]M ' &> /dev/null ); then
     git_status="$SPACESHIP_GIT_STATUS_MODIFIED$git_status"
   fi
 
   # Check for renamed files
-  if $(echo "$INDEX" | command grep '^R[ MD] ' &> /dev/null); then
+  if $( command echo "$INDEX" | command grep '^R[ MD] ' &> /dev/null ); then
     git_status="$SPACESHIP_GIT_STATUS_RENAMED$git_status"
   fi
 
   # Check for deleted files
-  if $(echo "$INDEX" | command grep '^[MARCDU ]D ' &> /dev/null); then
+  if $( command echo "$INDEX" | command grep '^[MARCDU ]D ' &> /dev/null ); then
     git_status="$SPACESHIP_GIT_STATUS_DELETED$git_status"
-  elif $(echo "$INDEX" | command grep '^D[ UM] ' &> /dev/null); then
+  elif $( command echo "$INDEX" | command grep '^D[ UM] ' &> /dev/null ); then
     git_status="$SPACESHIP_GIT_STATUS_DELETED$git_status"
   fi
 
   # Check for stashes
-  if $(command git rev-parse --verify refs/stash >/dev/null 2>&1); then
+  if $( command git rev-parse --verify refs/stash >/dev/null 2>&1 ); then
     git_status="$SPACESHIP_GIT_STATUS_STASHED$git_status"
   fi
 
   # Check for unmerged files
-  if $(echo "$INDEX" | command grep '^U[UDA] ' &> /dev/null); then
+  if $( command echo "$INDEX" | command grep '^U[UDA] ' &> /dev/null ); then
     git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
-  elif $(echo "$INDEX" | command grep '^AA ' &> /dev/null); then
+  elif $( command echo "$INDEX" | command grep '^AA ' &> /dev/null ); then
     git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
-  elif $(echo "$INDEX" | command grep '^DD ' &> /dev/null); then
+  elif $( command echo "$INDEX" | command grep '^DD ' &> /dev/null ); then
     git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
-  elif $(echo "$INDEX" | command grep '^[DA]U ' &> /dev/null); then
+  elif $( command echo "$INDEX" | command grep '^[DA]U ' &> /dev/null ); then
     git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
   fi
 
   # Check whether branch is ahead
   local is_ahead=false
-  if $(echo "$INDEX" | command grep '^## [^ ]\+ .*ahead' &> /dev/null); then
+  if $( command echo "$INDEX" | command grep '^## [^ ]\+ .*ahead' &> /dev/null ); then
     is_ahead=true
   fi
 
   # Check whether branch is behind
   local is_behind=false
-  if $(echo "$INDEX" | command grep '^## [^ ]\+ .*behind' &> /dev/null); then
+  if $( command echo "$INDEX" | command grep '^## [^ ]\+ .*behind' &> /dev/null ); then
     is_behind=true
   fi
 

--- a/sections/golang.zsh
+++ b/sections/golang.zsh
@@ -27,7 +27,7 @@ spaceship_golang() {
 
   spaceship::exists go || return
 
-  local go_version=$(go version | awk '{print substr($3, 3)}' )
+  local go_version=$( command go version | command awk '{print substr($3, 3)}' )
 
   spaceship::section \
     "$SPACESHIP_GOLANG_COLOR" \

--- a/sections/haskell.zsh
+++ b/sections/haskell.zsh
@@ -28,7 +28,7 @@ spaceship_haskell() {
   # The command is stack, so do not change this to haskell.
   spaceship::exists stack || return
 
-  local haskell_version=$(stack ghc -- --numeric-version --no-install-ghc)
+  local haskell_version=$( command stack ghc -- --numeric-version --no-install-ghc )
 
   spaceship::section \
     "$SPACESHIP_HASKELL_COLOR" \

--- a/sections/hg_branch.zsh
+++ b/sections/hg_branch.zsh
@@ -21,10 +21,10 @@ spaceship_hg_branch() {
 
   spaceship::is_hg || return
 
-  local hg_info=$(hg log -r . -T '{activebookmark}')
+  local hg_info=$( command hg log -r . -T '{activebookmark}' )
 
   if [[ -z $hg_info ]]; then
-    hg_info=$(hg branch)
+    hg_info=$( command hg branch )
   fi
 
   spaceship::section \

--- a/sections/hg_status.zsh
+++ b/sections/hg_status.zsh
@@ -32,11 +32,14 @@ spaceship_hg_status() {
   # provide uniform view across git and mercurial indicators
   if $( command echo "$INDEX" | command grep -E '^\? ' &> /dev/null ); then
     hg_status="$SPACESHIP_HG_STATUS_UNTRACKED$hg_status"
-  elif $( command echo "$INDEX" | command grep -E '^A ' &> /dev/null ); then
+  fi
+  if $( command echo "$INDEX" | command grep -E '^A ' &> /dev/null ); then
     hg_status="$SPACESHIP_HG_STATUS_ADDED$hg_status"
-  elif $( command echo "$INDEX" | command grep -E '^M ' &> /dev/null ); then
+  fi
+  if $( command echo "$INDEX" | command grep -E '^M ' &> /dev/null ); then
     hg_status="$SPACESHIP_HG_STATUS_MODIFIED$hg_status"
-  elif $( command echo "$INDEX" | command grep -E '^(R|!)' &> /dev/null ); then
+  fi
+  if $( command echo "$INDEX" | command grep -E '^(R|!)' &> /dev/null ); then
     hg_status="$SPACESHIP_HG_STATUS_DELETED$hg_status"
   fi
 

--- a/sections/hg_status.zsh
+++ b/sections/hg_status.zsh
@@ -26,17 +26,17 @@ spaceship_hg_status() {
 
   spaceship::is_hg || return
 
-  local INDEX=$(hg status 2>/dev/null) hg_status=""
+  local INDEX=$( command hg status 2>/dev/null ) hg_status=""
 
   # Indicators are suffixed instead of prefixed to each other to
   # provide uniform view across git and mercurial indicators
-  if $(echo "$INDEX" | grep -E '^\? ' &> /dev/null); then
+  if $( command echo "$INDEX" | command grep -E '^\? ' &> /dev/null ); then
     hg_status="$SPACESHIP_HG_STATUS_UNTRACKED$hg_status"
-  elif $(echo "$INDEX" | grep -E '^A ' &> /dev/null); then
+  elif $( command echo "$INDEX" | command grep -E '^A ' &> /dev/null ); then
     hg_status="$SPACESHIP_HG_STATUS_ADDED$hg_status"
-  elif $(echo "$INDEX" | grep -E '^M ' &> /dev/null); then
+  elif $( command echo "$INDEX" | command grep -E '^M ' &> /dev/null ); then
     hg_status="$SPACESHIP_HG_STATUS_MODIFIED$hg_status"
-  elif $(echo "$INDEX" | grep -E '^(R|!)' &> /dev/null); then
+  elif $( command echo "$INDEX" | command grep -E '^(R|!)' &> /dev/null ); then
     hg_status="$SPACESHIP_HG_STATUS_DELETED$hg_status"
   fi
 

--- a/sections/jobs.zsh
+++ b/sections/jobs.zsh
@@ -20,7 +20,7 @@ SPACESHIP_JOBS_COLOR="${SPACESHIP_JOBS_COLOR="blue"}"
 spaceship_jobs() {
   [[ $SPACESHIP_JOBS_SHOW == false ]] && return
 
-  local jobs_amount=$( (jobs) | wc -l )
+  local jobs_amount=$( ( jobs ) | command wc -l )
 
   [[ $jobs_amount -gt 0 ]] || return
   [[ $jobs_amount -eq 1 ]] && jobs_amount=''

--- a/sections/julia.zsh
+++ b/sections/julia.zsh
@@ -27,7 +27,7 @@ spaceship_julia() {
 
   spaceship::exists julia || return
 
-  local julia_version=$(julia --version | grep --color=never -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]')
+  local julia_version=$( command julia --version | command grep --color=never -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]')
 
   spaceship::section \
     "$SPACESHIP_JULIA_COLOR" \

--- a/sections/kubecontext.zsh
+++ b/sections/kubecontext.zsh
@@ -27,7 +27,7 @@ spaceship_kubecontext() {
 
   spaceship::exists kubectl || return
 
-  local kube_context=$(kubectl config current-context 2>/dev/null)
+  local kube_context=$( command kubectl config current-context 2>/dev/null )
 
   [[ -z $kube_context ]] && return
 

--- a/sections/node.zsh
+++ b/sections/node.zsh
@@ -29,13 +29,13 @@ spaceship_node() {
   local node_version
 
   if spaceship::exists nvm; then
-    node_version=$(nvm current 2>/dev/null)
+    node_version=$( command nvm current 2>/dev/null )
     [[ $node_version == "system" || $node_version == "node" ]] && return
   elif spaceship::exists nodenv; then
-    node_version=$(nodenv version-name)
+    node_version=$( command nodenv version-name )
     [[ $node_version == "system" || $node_version == "node" ]] && return
   elif spaceship::exists node; then
-    node_version=$(node -v 2>/dev/null)
+    node_version=$( command node -v 2>/dev/null )
   else
     return
   fi

--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -29,7 +29,7 @@ spaceship_package() {
   spaceship::exists npm || return
 
   # Grep and cut out package version
-  local package_version=$(grep -E '"version": "v?([0-9]+\.){1,}' package.json | cut -d\" -f4 2> /dev/null)
+  local package_version=$( command grep -E '"version": "v?([0-9]+\.){1,}' package.json | command cut -d\" -f4 2> /dev/null)
 
   # Handle version not found
   if [ ! "$package_version" ]; then

--- a/sections/php.zsh
+++ b/sections/php.zsh
@@ -27,7 +27,7 @@ spaceship_php() {
 
   spaceship::exists php || return
 
-  local php_version=$(php -v 2>&1 | grep --color=never -oe "^PHP\s*[0-9.]\+" | awk '{print $2}')
+  local php_version=$( command php -v 2>&1 | command grep --color=never -oe "^PHP\s*[0-9.]\+" | command awk '{print $2}' )
 
   spaceship::section \
     "$SPACESHIP_PHP_COLOR" \

--- a/sections/pyenv.zsh
+++ b/sections/pyenv.zsh
@@ -27,7 +27,7 @@ spaceship_pyenv() {
 
   spaceship::exists pyenv || return # Do nothing if pyenv is not installed
 
-  local pyenv_status=${$(pyenv version-name 2>/dev/null)//:/ }
+  local pyenv_status=${$( command pyenv version-name 2> /dev/null )//:/ }
 
   spaceship::section \
     "$SPACESHIP_PYENV_COLOR" \

--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -28,13 +28,13 @@ spaceship_ruby() {
   local ruby_version
 
   if spaceship::exists rvm-prompt; then
-    ruby_version=$(rvm-prompt i v g)
+    ruby_version=$( command rvm-prompt i v g )
   elif spaceship::exists chruby; then
-    ruby_version=$(chruby | sed -n -e 's/ \* //p')
+    ruby_version=$( command chruby | command sed -n -e 's/ \* //p' )
   elif spaceship::exists rbenv; then
-    ruby_version=$(rbenv version-name)
+    ruby_version=$( command rbenv version-name )
   elif spaceship::exists asdf; then
-    ruby_version=$(asdf current ruby | awk '{print $1}')
+    ruby_version=$( command asdf current ruby | command awk '{print $1}' )
   else
     return
   fi

--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -23,7 +23,7 @@ spaceship_ruby() {
   [[ $SPACESHIP_RUBY_SHOW == false ]] && return
 
   # Show versions only for Ruby-specific folders
-  [[ -f Gemfile || -f Rakefile || -n *.rb(#qN^/) ]] || return
+  [[ -f Gemfile || -f Rakefile || -n *.rb(\#qN^/) ]] || return
 
   local ruby_version
 

--- a/sections/rust.zsh
+++ b/sections/rust.zsh
@@ -27,7 +27,7 @@ spaceship_rust() {
 
   spaceship::exists rustc || return
 
-  local rust_version=$(rustc --version | grep --color=never -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]')
+  local rust_version=$( command rustc --version | command grep --color=never -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]' )
 
   spaceship::section \
     "$SPACESHIP_RUST_COLOR" \

--- a/sections/swift.zsh
+++ b/sections/swift.zsh
@@ -26,10 +26,10 @@ spaceship_swift() {
   local swift_version
 
   if [[ $SPACESHIP_SWIFT_SHOW_GLOBAL == true ]] ; then
-    swift_version=$(swiftenv version | sed 's/ .*//')
+    swift_version=$( command swiftenv version | command sed 's/ .*//' )
   elif [[ $SPACESHIP_SWIFT_SHOW_LOCAL == true ]] ; then
     if swiftenv version | grep ".swift-version" > /dev/null; then
-      swift_version=$(swiftenv version | sed 's/ .*//')
+      swift_version=$( command swiftenv version | command sed 's/ .*//' )
     fi
   fi
 

--- a/sections/xcode.zsh
+++ b/sections/xcode.zsh
@@ -26,10 +26,10 @@ spaceship_xcode() {
   local xcode_path
 
   if [[ $SPACESHIP_SWIFT_SHOW_GLOBAL == true ]] ; then
-    xcode_path=$(xcenv version | sed 's/ .*//')
+    xcode_path=$( command xcenv version | command sed 's/ .*//' )
   elif [[ $SPACESHIP_SWIFT_SHOW_LOCAL == true ]] ; then
     if xcenv version | grep ".xcode-version" > /dev/null; then
-      xcode_path=$(xcenv version | sed 's/ .*//')
+      xcode_path=$( command xcenv version | command sed 's/ .*//' )
     fi
   fi
 
@@ -37,7 +37,7 @@ spaceship_xcode() {
     local xcode_version_path=$xcode_path"/Contents/version.plist"
     if [ -f ${xcode_version_path} ]; then
       if spaceship::exists defaults; then
-        local xcode_version=$(defaults read ${xcode_version_path} CFBundleShortVersionString)
+        local xcode_version=$( command defaults read ${xcode_version_path} CFBundleShortVersionString )
 
         spaceship::section \
           "$SPACESHIP_XCODE_COLOR" \


### PR DESCRIPTION
#### Description

Use of `command` directive to avoid possible user aliases. Imagine I have installed [ripgrep](https://github.com/BurntSushi/ripgrep) and defined an alias to use it instead of grep in my `~/.profile`:

```bash
# Aliases
...
alias ls="exa -bghHS --git"
alias grep="rg"
...
```

`grep` uses `-E` as parameter to search for a regular expression, but `rg` doesn't. It uses `-e` to search for a regular expression and `-E` to use a specific encode:

```
command grep --help   
Usage: grep [OPTION]... PATTERN [FILE]...
Search for PATTERN in each FILE or standard input.
PATTERN is, by default, a basic regular expression (BRE).
Example: grep -i 'hello world' menu.h main.c

Regexp selection and interpretation:
  -E, --extended-regexp     PATTERN is an extended regular expression (ERE)
...
```

``` 
command rg -E --help
ripgrep 0.8.1
Andrew Gallant <jamslam@gmail.com>

ripgrep (rg) recursively searches your current directory for a regex pattern.
By default, ripgrep will respect your `.gitignore` and automatically skip
hidden files/directories and binary files.

...

USAGE:
    rg [OPTIONS] PATTERN [PATH ...]
    rg [OPTIONS] [-e PATTERN ...] [-f FILE ...] [PATH ...]
    rg [OPTIONS] --files [PATH ...]
    rg [OPTIONS] --type-list

ARGS:
...

OPTIONS:
             
    -E, --encoding <ENCODING>               
            Specify the text encoding that ripgrep will use on all files searched. The
            default value is 'auto', which will cause ripgrep to do a best effort automatic
            detection of encoding on a per-file basis. Other supported values can be found
            in the list of labels here:
            https://encoding.spec.whatwg.org/#concept-encoding-get

    -e, --regexp <PATTERN>...               
            A pattern to search for. This option can be provided multiple times, where
            all patterns given are searched. Lines matching at least one of the provided
            patterns are printed. This flag can also be used when searching for patterns
            that start with a dash.
            
            For example, to search for the literal '-foo', you can use this flag:
            
                rg -e -foo
            
            You can also use the special '--' delimiter to indicate that no more flags
            will be provided. Namely, the following is equivalent to the above:
            
                rg -- -foo

```

So, I think it's a good idea to ensure the use of base commands avoiding aliases defined by users.
