### PR TITLE
Add option to expand user path

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -137,6 +137,7 @@ Directory is always shown and truncated to the value of `SPACESHIP_DIR_TRUNC`. W
 | `SPACESHIP_DIR_TRUNC` | `3` | Number of folders of cwd to show in prompt, 0 to show all |
 | `SPACESHIP_DIR_TRUNC_REPO` | `true` | While in `git` repo, show only root directory and folders inside it |
 | `SPACESHIP_DIR_COLOR` | `cyan` | Color of directory section |
+| `SPACESHIP_DIR_EXPAND_USER_PATH` | `false` | If `true`, the path will start from `/Users/foobar/` instead of `~` |
 
 ### Git (`git`)
 

--- a/sections/dir.zsh
+++ b/sections/dir.zsh
@@ -13,6 +13,7 @@ SPACESHIP_DIR_SUFFIX="${SPACESHIP_DIR_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}
 SPACESHIP_DIR_TRUNC="${SPACESHIP_DIR_TRUNC=3}"
 SPACESHIP_DIR_TRUNC_REPO="${SPACESHIP_DIR_TRUNC_REPO=true}"
 SPACESHIP_DIR_COLOR="${SPACESHIP_DIR_COLOR="cyan"}"
+SPACESHIP_DIR_EXPAND_USER_PATH="${SPACESHIP_DIR_EXPAND_USER_PATH=false}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -26,9 +27,13 @@ spaceship_dir() {
   # Threat repo root as a top-level directory or not
   if [[ $SPACESHIP_DIR_TRUNC_REPO == true ]] && spaceship::is_git; then
     local git_root=$(git rev-parse --show-toplevel)
-    dir="$git_root:t${$(expr $(pwd -P) : "$git_root\(.*\)")}"
+    dir="$git_root:t${$(expr $(pwd) : "$git_root\(.*\)")}"
   else
-    dir="%${SPACESHIP_DIR_TRUNC}~"
+    local path_start="~"
+    if [[ $SPACESHIP_DIR_EXPAND_USER_PATH == true ]]; then
+      local path_start="/"
+    fi
+    dir="%${SPACESHIP_DIR_TRUNC}${path_start}"
   fi
 
   spaceship::section \


### PR DESCRIPTION
#### Description
Add option to expand user path from `~` to `/Users/foobar`
Option is a Bool under Dir category and is named `SPACESHIP_DIR_EXPAND_USER_PATH`