### PR TITLE
jobs.zsh: Add $SPACESHIP_JOBS_SHOW_AMOUNT variable

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -520,6 +520,7 @@ This section show only when there are active jobs in the background.
 | `SPACESHIP_JOBS_PREFIX` | ` ` | Prefix before the jobs indicator |
 | `SPACESHIP_JOBS_SUFFIX` | ` ` | Suffix after the jobs indicator |
 | `SPACESHIP_JOBS_SYMBOL` | `✦` | Character to be shown when jobs are hiding |
+| `SPACESHIP_JOBS_SHOW_AMOUNT` | `true` | Show number of jobs (`true`, `false`, `always`) |
 | `SPACESHIP_JOBS_COLOR` | `blue` | Color of background jobs section |
 
 ### Exit code (`exit_code`)

--- a/sections/jobs.zsh
+++ b/sections/jobs.zsh
@@ -11,6 +11,7 @@ SPACESHIP_JOBS_PREFIX="${SPACESHIP_JOBS_PREFIX=""}"
 SPACESHIP_JOBS_SUFFIX="${SPACESHIP_JOBS_SUFFIX=" "}"
 SPACESHIP_JOBS_SYMBOL="${SPACESHIP_JOBS_SYMBOL="✦"}"
 SPACESHIP_JOBS_COLOR="${SPACESHIP_JOBS_COLOR="blue"}"
+SPACESHIP_JOBS_SHOW_AMOUNT="${SPACESHIP_JOBS_SHOW_AMOUNT=true}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -23,7 +24,8 @@ spaceship_jobs() {
   local jobs_amount=$( (jobs) | wc -l )
 
   [[ $jobs_amount -gt 0 ]] || return
-  [[ $jobs_amount -eq 1 ]] && jobs_amount=''
+  [[ $jobs_amount -eq 1 ]] && [[ $SPACESHIP_JOBS_SHOW_AMOUNT == true ]] && jobs_amount=''
+  [[ $SPACESHIP_JOBS_SHOW_AMOUNT == false ]] && jobs_amount=''
 
   spaceship::section \
     "$SPACESHIP_JOBS_COLOR" \


### PR DESCRIPTION
First of all, thanks a lot for this amazing project!

#### Description

I don't like the used jobs symbol and I prefer see the word 'jobs' (with the suffix variable) but the number of jobs isn't shown when there is only one. 

I propose don't reset the $jobs_amount variable if the $SPACESHIP_JOBS_SHOW_AMOUNT is always

Config example:
```
export SPACESHIP_JOBS_SYMBOL=''
export SPACESHIP_JOBS_SHOW_AMOUNT='always'
export SPACESHIP_JOBS_SUFFIX=' \e[36mjobs\e[0m '
```

#### Screenshot
![1_jobs](https://user-images.githubusercontent.com/3269878/40750301-24ccd704-6467-11e8-8e1e-9915f4a5e0af.png)

I hope to be useful but perhaps another solution is better