### PR TITLE
Add SPACESHIP_JOBS_AMOUNT_THRESHOLD variable

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -523,6 +523,7 @@ This section show only when there are active jobs in the background.
 | `SPACESHIP_JOBS_SUFFIX` | ` ` | Suffix after the jobs indicator |
 | `SPACESHIP_JOBS_SYMBOL` | `✦` | Character to be shown when jobs are hiding |
 | `SPACESHIP_JOBS_COLOR` | `blue` | Color of background jobs section |
+| `SPACESHIP_JOBS_AMOUNT_THRESHOLD` | `1` | Number of jobs after which job count will be shown |
 
 ### Exit code (`exit_code`)
 

--- a/sections/jobs.zsh
+++ b/sections/jobs.zsh
@@ -13,6 +13,7 @@ SPACESHIP_JOBS_SYMBOL="${SPACESHIP_JOBS_SYMBOL="✦"}"
 SPACESHIP_JOBS_COLOR="${SPACESHIP_JOBS_COLOR="blue"}"
 SPACESHIP_JOBS_AMOUNT_PREFIX="${SPACESHIP_JOBS_AMOUNT_PREFIX=""}"
 SPACESHIP_JOBS_AMOUNT_SUFFIX="${SPACESHIP_JOBS_AMOUNT_SUFFIX=""}"
+SPACESHIP_JOBS_AMOUNT_THRESHOLD="${SPACESHIP_JOBS_AMOUNT_THRESHOLD=1}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -26,7 +27,7 @@ spaceship_jobs() {
 
   [[ $jobs_amount -gt 0 ]] || return
 
-  if [[ $jobs_amount -eq 1 ]]; then
+  if [[ $jobs_amount -le $SPACESHIP_JOBS_AMOUNT_THRESHOLD ]]; then
     jobs_amount=''
     SPACESHIP_JOBS_AMOUNT_PREFIX=''
     SPACESHIP_JOBS_AMOUNT_SUFFIX=''


### PR DESCRIPTION
First of all, thanks a lot for this amazing project!

#### Description

I don't like the used jobs symbol and I prefer see the word 'jobs' (with the suffix variable) but the number of jobs isn't shown when there is only one. 

I propose don't reset the $jobs_amount variable if the $SPACESHIP_JOBS_SHOW_AMOUNT_ALWAYS is yes

Config example:
```
export SPACESHIP_JOBS_SYMBOL=''
export SPACESHIP_JOBS_SHOW_AMOUNT_ALWAYS='yes'
export SPACESHIP_JOBS_SUFFIX=' \e[36mjobs\e[0m '
```

#### Screenshot
![1_jobs](https://user-images.githubusercontent.com/3269878/40750301-24ccd704-6467-11e8-8e1e-9915f4a5e0af.png)

I hope to be useful but perhaps another solution is better