### PR TITLE
Update link to preview in Troubleshooting page

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -104,7 +104,7 @@ In _iTerm_ follow these instructions:
 
 ## Why doesn't my prompt look like the preview?
 
-![preview](../preview.gif)
+![preview](https://user-images.githubusercontent.com/10276208/36086434-5de52ace-0ff2-11e8-8299-c67f9ab4e9bd.gif)
 
 Preview shows `spaceship` prompt setup with:
 


### PR DESCRIPTION
`preview.gif` was removed from repo in 55f1476d5451923f25b9be99fac26ea529e70f61. But link in troubleshooting wasn't updated. Noted in https://github.com/denysdovhan/spaceship-prompt/issues/495#issuecomment-415981385