### PR TITLE
Center title and links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@
 
 Spaceship is a minimalistic, powerful and extremely customizable [Zsh][zsh-url] prompt. It combines everything you may need for convenient work, without unnecessary complications, like a real spaceship.
 
+<p align="center">
+  <img alt="Spaceship with Hyper and One Dark" src="https://user-images.githubusercontent.com/10276208/36086434-5de52ace-0ff2-11e8-8299-c67f9ab4e9bd.gif" width="980px">
+</p>
+
+<sub>You can find more examples with different color schemes in <a href="https://github.com/denysdovhan/spaceship-prompt/wiki/Screenshots">Screenshots </a>wiki-page.</sub>
+
 ## Features
 
 * Clever hostname and username displaying.
@@ -101,14 +107,6 @@ Spaceship is a minimalistic, powerful and extremely customizable [Zsh][zsh-url] 
 * Execution time of the last command if it exceeds the set threshold.
 
 Want more features? Please, [open an issue](https://github.com/denysdovhan/spaceship-prompt/issues/new/choose) or send pull request.
-
-## Preview
-
-<p align="center">
-  <img alt="Spaceship with Hyper and One Dark" src="https://user-images.githubusercontent.com/10276208/36086434-5de52ace-0ff2-11e8-8299-c67f9ab4e9bd.gif" width="980px">
-</p>
-
-You can find more examples with different color schemes in [Screenshots](https://github.com/denysdovhan/spaceship-prompt/wiki/Screenshots) wiki-page.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,57 @@
-<div align="center">
+<h1 align="center">
   <a href="https://github.com/denysdovhan/spaceship-prompt">
     <img alt="spaceship →~ prompt" src="https://cloud.githubusercontent.com/assets/3459374/21679181/46e24706-d34b-11e6-82ee-5efb3d2ba70f.png" width="400">
   </a>
+  <br>🚀⭐ Spaceship ZSH <br>
+</h1>
+
+<h4 align="center">
+  <a href="http://zsh.org" target="_blank"><code>Zsh</code></a> prompt for Astronauts.
+</h4>
+
+<p align="center">
+  <!-- NPM Version -->
+    <a href="https://npmjs.org/package/spaceship-prompt">
+    <img src="https://img.shields.io/npm/v/spaceship-prompt.svg?style=flat-square"
+      alt="NPM Version" />
+  </a>
+
+  <a href="https://travis-ci.org/denysdovhan/spaceship-prompt">
+    <img src="https://img.shields.io/travis/denysdovhan/spaceship-prompt.svg?style=flat-square"
+      alt="CI Status" />
+  </a>
+
+  <a href="http://zsh.org/">
+    <img src="https://img.shields.io/badge/zsh-%3E%3Dv5.2-777777.svg?style=flat-square"
+      alt="Zsh Version" />
+  </a>
+
+  <a href="#donate">
+    <img src="https://img.shields.io/badge/$-donate-ff69b4.svg?style=flat-square"
+      alt="Donate" />
+  </a>
+</p>
+
+<div align="center">
+  <h4>
+    <a href="https://denysdovhan.com/spaceship-prompt/">Website |</a>
+    <a href="#installing">Install |</a>
+    <a href="#features">Features |</a>
+    <a href="./docs/Options.md">Options |</a>
+    <a href="./docs/API.md">API</a>
+  </h4>
 </div>
 
-# 🚀⭐ Spaceship ZSH
-
-[![NPM version][npm-image]][npm-url]
-[![Build status][ci-image]][ci-url]
-[![Zsh][zsh-image]][zsh-url]
-[![Donate with card][donate-card-image]][donate-readme]
-[![Donate with Bitcoin][donate-btc-image]][donate-readme]
-[![Donate with Ethereum][donate-eth-image]][donate-readme]
-
-> A [Zsh][zsh-url] prompt for Astronauts.
+<div align="center">
+  <sub>Built with ❤︎ by
+  <a href="https://denysdovhan.com">Denys Dovhan</a> and
+  <a href="https://github.com/denysdovhan/spaceship-prompt/graphs/contributors">contributors </a>
+</div>
+<br>
 
 Spaceship is a minimalistic, powerful and extremely customizable [Zsh][zsh-url] prompt. It combines everything you may need for convenient work, without unnecessary complications, like a real spaceship.
 
-Currently it shows:
+## Features
 
 * Clever hostname and username displaying.
 * Prompt character turns red if the last command exits with non-zero code.
@@ -246,11 +280,7 @@ MIT © [Denys Dovhan](http://denysdovhan.com)
 [zsh-url]: http://zsh.org/
 [zsh-image]: https://img.shields.io/badge/zsh-%3E%3Dv5.2-777777.svg?style=flat-square
 
-[donate-readme]: https://github.com/denysdovhan/spaceship-prompt#donate
 [donate-card-url]: https://www.liqpay.com/en/checkout/380951100392
-[donate-card-image]: https://img.shields.io/badge/donate-LiqPay-blue.svg?style=flat-square
-[donate-btc-image]: https://img.shields.io/badge/donate-BTC-yellow.svg?style=flat-square
-[donate-eth-image]: https://img.shields.io/badge/donate-ETH-gray.svg?style=flat-square
 
 <!-- References -->
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Spaceship is a minimalistic, powerful and extremely customizable [Zsh][zsh-url] 
   <img alt="Spaceship with Hyper and One Dark" src="https://user-images.githubusercontent.com/10276208/36086434-5de52ace-0ff2-11e8-8299-c67f9ab4e9bd.gif" width="980px">
 </p>
 
-<sub>You can find more examples with different color schemes in <a href="https://github.com/denysdovhan/spaceship-prompt/wiki/Screenshots">Screenshots </a>wiki-page.</sub>
+<sub>Vist <a href="./docs/Troubleshooting.md#why-doesnt-my-prompt-look-like-the-preview">Troubleshooting</a> for similar setup and find more examples with different color schemes in <a href="https://github.com/denysdovhan/spaceship-prompt/wiki/Screenshots">Screenshots </a>wiki-page.</sub>
 
 ## Features
 


### PR DESCRIPTION
This is intended to improve accessibility of documentation and better UI. But, this comes at cost of including `HTML` directly inside `markdown` due to limitations of `markdown` syntax and readability of `README`. 

**Included Changes**

- Title, tagline and badges centered
- Quick link to website, install instructions, features, options and API. Centered and separated with vertical bar (`|`)
- Moved preview to top, So user don't have to scroll the lengthy features list to see how beautiful the prompt looks 
- Link to contributors pages
- Link to preview setup just below preview (It have been asked so.. many times)

Direct link to branch page: [salmanulfarzy/spaceship-prompt@center-doc
](https://github.com/salmanulfarzy/spaceship-prompt/tree/center-doc)

-------------

**Before**

![master doc](https://user-images.githubusercontent.com/10276208/44702884-23b91480-aab3-11e8-8b89-21322312ed9d.png)

**After**

![doc UI changes](https://user-images.githubusercontent.com/10276208/44702856-fff5ce80-aab2-11e8-947c-0cbd3c39cd59.png)