### PR TITLE
Add image for powerline dir lock symbol

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -139,7 +139,7 @@ If current directory is write-protected or if current user has not enough rights
 | `SPACESHIP_DIR_TRUNC_PREFIX` | ` ` | Prefix before cwd when it's truncated. For example `…/` or `.../`, empty to disable |
 | `SPACESHIP_DIR_TRUNC_REPO` | `true` | While in `git` repo, show only root directory and folders inside it |
 | `SPACESHIP_DIR_COLOR` | `cyan` | Color of directory section |
-| `SPACESHIP_DIR_LOCK_SYMBOL` | `·` | The symbol displayed if directory is write-protected |
+| `SPACESHIP_DIR_LOCK_SYMBOL` | ![·](https://user-images.githubusercontent.com/10276208/46248218-4af95d80-c434-11e8-8e25-595d792503f1.png) | The symbol displayed if directory is write-protected (requires powerline patched font) |
 | `SPACESHIP_DIR_LOCK_COLOR` | `red` | Color for the lock symbol |
 
 ### Git (`git`)


### PR DESCRIPTION
Document `SPACESHIP_DIR_LOCK_SYMBOL` requires powerline patached font
and add lock symbol as image in documentation for proper display on browsers.