### PR TITLE
Let's use cut instead of grep!

### DIFF
--- a/sections/rust.zsh
+++ b/sections/rust.zsh
@@ -27,7 +27,7 @@ spaceship_rust() {
 
   spaceship::exists rustc || return
 
-  local rust_version=$(rustc --version | grep --color=never -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]')
+  local rust_version=$(rustc --version | cut -d' ' -f2)
 
   spaceship::section \
     "$SPACESHIP_RUST_COLOR" \


### PR DESCRIPTION
#### Description

This is a small change that is being [upstreamed from the "spacefish" fork](https://github.com/matchai/spacefish/pull/77) of spaceship-prompt. While porting this prompt section to be fish-shell compatible, we found a more elegant solution for returning the rust version number.

The main advantage with using cut, over using grep is increased compatibility with other coreutils while being much more concise. This has been tested using GNU, BSD, [Ripgrep](https://github.com/BurntSushi/ripgrep), Busybox and Toybox coreutils — the latter three would have failed otherwise, due to a grep flag incompatibility.

This change increases compatibility and cleans up a line of code.

#### Screenshot(s)
![image](https://user-images.githubusercontent.com/26250962/46448068-157aaa00-c77d-11e8-8a5c-d3e6cfe1db40.png)
