### PR TITLE
Added a way to enable/disable verbose rust versioning

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -337,6 +337,7 @@ Rust section is shown only in directories that contain `Cargo.toml` or any other
 | `SPACESHIP_RUST_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Rust section |
 | `SPACESHIP_RUST_SYMBOL` | `𝗥·` | Character to be shown before Rust version |
 | `SPACESHIP_RUST_COLOR` | `red` | Color of Rust section |
+| `SPACESHIP_RUST_VERBOSE_VERSION` | `false` | Show what branch is being used, if any. (Beta, Nightly) |
 
 ### Haskell (`haskell`)
 

--- a/sections/rust.zsh
+++ b/sections/rust.zsh
@@ -13,6 +13,7 @@ SPACESHIP_RUST_PREFIX="${SPACESHIP_RUST_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX
 SPACESHIP_RUST_SUFFIX="${SPACESHIP_RUST_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_RUST_SYMBOL="${SPACESHIP_RUST_SYMBOL="𝗥 "}"
 SPACESHIP_RUST_COLOR="${SPACESHIP_RUST_COLOR="red"}"
+SPACESHIP_RUST_VERBOSE_VERSION="${SPACESHIP_RUST_VERBOSE_VERSION=false}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -28,6 +29,10 @@ spaceship_rust() {
   spaceship::exists rustc || return
 
   local rust_version=$(rustc --version | cut -d' ' -f2)
+
+  if [[ $SPACESHIP_RUST_VERBOSE_VERSION == false ]]; then
+  	local rust_version=$($rust_version | cut -d'-' -f1) # Cut off -suffixes from version. "v1.30.0-beta.11" or "v1.30.0-nightly"
+  fi
 
   spaceship::section \
     "$SPACESHIP_RUST_COLOR" \


### PR DESCRIPTION
#### Description

An expansion on pull request #520 to add a config option to toggle showing channel suffixes in the Rust version, if you do not use the stable branch. If you do use the stable branch, this config option doesn't change anything.

**SHOW_RUST_VERBOSE_VERSION=true**
`R v1.30.0-nightly` / `R v1.30.0-beta.11`

**SHOW_RUST_VERBOSE_VERSION=false**
`R v1.30.0`
