### PR TITLE
Use AWS_PROFILE variable for aws named profiles

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -377,7 +377,7 @@ Docker section is shown only in directories that contain `Dockerfile` or `docker
 
 ### Amazon Web Services (AWS) (`aws`)
 
-Shows selected Amazon Web Services profile using '[named profiles](http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html)'.
+Shows selected Amazon Web Services profile configured using  [`AWS_PROFILE`](http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html) variable.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |

--- a/sections/aws.zsh
+++ b/sections/aws.zsh
@@ -26,12 +26,12 @@ spaceship_aws() {
   spaceship::exists aws || return
 
   # Is the current profile not the default profile
-  [[ -z $AWS_DEFAULT_PROFILE ]] || [[ "$AWS_DEFAULT_PROFILE" == "default" ]] && return
+  [[ -z $AWS_PROFILE ]] || [[ "$AWS_PROFILE" == "default" ]] && return
 
   # Show prompt section
   spaceship::section \
     "$SPACESHIP_AWS_COLOR" \
     "$SPACESHIP_AWS_PREFIX" \
-    "${SPACESHIP_AWS_SYMBOL}$AWS_DEFAULT_PROFILE" \
+    "${SPACESHIP_AWS_SYMBOL}$AWS_PROFILE" \
     "$SPACESHIP_AWS_SUFFIX"
 }


### PR DESCRIPTION
## Description
Refactor the AWS section to use the correct environment variable that the (new) AWS cli uses. Its using [named profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html).

Fixes #259
