### PR TITLE
Remove argument from char test shebang

### DIFF
--- a/tests/char.test.zsh
+++ b/tests/char.test.zsh
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh +x
+#!/usr/bin/env zsh
 
 # Required for shunit2 to run correctly
 setopt shwordsplit


### PR DESCRIPTION
shebang treats arguments differently on various operating systems.
Linux kernel treats[1] everything following the first word in the
shebang line as a single argument

[1]: https://lwn.net/Articles/630727
[2]: https://stackoverflow.com/a/4304187
[3]: https://www.in-ulm.de/~mascheck/various/shebang