### PR TITLE
Group and quote local variable declaration

### DIFF
--- a/sections/char.zsh
+++ b/sections/char.zsh
@@ -22,15 +22,13 @@ SPACESHIP_CHAR_COLOR_SECONDARY="${SPACESHIP_CHAR_COLOR_SECONDARY="yellow"}"
 # Paint $PROMPT_SYMBOL in red if previous command was fail and
 # paint in green if everything was OK.
 spaceship_char() {
-  local 'color'
+  local 'color' 'char'
 
   if [[ $RETVAL -eq 0 ]]; then
     color="$SPACESHIP_CHAR_COLOR_SUCCESS"
   else
     color="$SPACESHIP_CHAR_COLOR_FAILURE"
   fi
-
-  local char
 
   if [[ $UID -eq 0 ]]; then
     char="$SPACESHIP_CHAR_SYMBOL_ROOT"


### PR DESCRIPTION
Moved local variabl declarations to top of the `char` section and quoted to prevent being overridden by global aliases.