### PR TITLE
Added option to use Virtualenv python version instead Pyenv global one

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ Spaceship is a minimalistic, powerful and extremely customizable [Zsh][zsh-url] 
 * Current Julia version (`ஃ`).
 * Current Docker version and connected machine (`🐳`).
 * Current Amazon Web Services (AWS) profile (`☁️`) ([Using named profiles](http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html)).
+* Current Python version, through `python` (`🐍`) or through `pyenv` (`🐍`).
 * Current Python virtualenv.
 * Current Conda virtualenv (`🅒`).
-* Current Python pyenv (`🐍`).
 * Current .NET SDK version, through dotnet-cli (`.NET`).
 * Current Ember.js version, through ember-cli (`🐹`).
 * Current Kubectl context (`☸️`).

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -37,7 +37,7 @@ SPACESHIP_PROMPT_ORDER=(
   aws           # Amazon Web Services section
   venv          # virtualenv section
   conda         # conda virtualenv section
-  pyenv         # Pyenv section
+  python        # Python section
   dotnet        # .NET section
   ember         # Ember.js section
   kubecontext   # Kubectl context section
@@ -424,6 +424,18 @@ Show activated conda virtual environment. Disable native conda prompt by `conda 
 | `SPACESHIP_CONDA_SYMBOL` | `🅒·` | Character to be shown before conda virtualenv section |
 | `SPACESHIP_CONDA_COLOR` | `blue` | Color of conda virtualenv environment section |
 
+### Python (`python`)
+
+python section is shown only in directories that contain `requirements.txt`, `Pipfile` or any other file with `.py` extension.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_PYTHON_SHOW` | `true` | Show current Python version or not |
+| `SPACESHIP_PYTHON_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the python section |
+| `SPACESHIP_PYTHON_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the python section |
+| `SPACESHIP_PYTHON_SYMBOL` | `🐍·` | Character to be shown before Python version |
+| `SPACESHIP_PYTHON_COLOR` | `220` | Color of Python section |
+
 ### Pyenv (`pyenv`)
 
 pyenv section is shown only in directories that contain `requirements.txt` or any other file with `.py` extension.
@@ -435,7 +447,6 @@ pyenv section is shown only in directories that contain `requirements.txt` or an
 | `SPACESHIP_PYENV_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the pyenv section |
 | `SPACESHIP_PYENV_SYMBOL` | `🐍·` | Character to be shown before Pyenv version |
 | `SPACESHIP_PYENV_COLOR` | `yellow` | Color of Pyenv section |
-| `SPACESHIP_PYENV_USE_VENV` | `false` | If the virtualenv python version should be used instead Pyenv |
 
 ### .NET (`dotnet`)
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -435,6 +435,7 @@ pyenv section is shown only in directories that contain `requirements.txt` or an
 | `SPACESHIP_PYENV_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the pyenv section |
 | `SPACESHIP_PYENV_SYMBOL` | `🐍·` | Character to be shown before Pyenv version |
 | `SPACESHIP_PYENV_COLOR` | `yellow` | Color of Pyenv section |
+| `SPACESHIP_PYENV_USE_VENV` | `false` | If the virtualenv python version should be used instead Pyenv |
 
 ### .NET (`dotnet`)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@
   * [Amazon Web Services (aws)](/docs/Options.md#amazon-web-services-aws-aws)
   * [Virtualenv (venv)](/docs/Options.md#virtualenv-venv)
   * [Conda Virtualenv (conda)](/docs/Options.md#conda-virtualenv-conda)
+  * [Python (python)](/docs/Options.md#python-python)
   * [Pyenv (pyenv)](/docs/Options.md#pyenv-pyenv)
   * [.NET (dotnet)](/docs/Options.md#net-dotnet)
   * [Ember (ember)](/docs/Options.md#emberjs-ember)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -63,7 +63,7 @@ SPACESHIP_PROMPT_ORDER=(
   aws           # Amazon Web Services section
   venv          # virtualenv section
   conda         # conda virtualenv section
-  pyenv         # Pyenv section
+  python        # Python section
   dotnet        # .NET section
   # ember       # Ember.js section (Disabled)
   kubecontext   # Kubectl context section

--- a/sections/pyenv.zsh
+++ b/sections/pyenv.zsh
@@ -13,6 +13,7 @@ SPACESHIP_PYENV_PREFIX="${SPACESHIP_PYENV_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREF
 SPACESHIP_PYENV_SUFFIX="${SPACESHIP_PYENV_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_PYENV_SYMBOL="${SPACESHIP_PYENV_SYMBOL="🐍 "}"
 SPACESHIP_PYENV_COLOR="${SPACESHIP_PYENV_COLOR="yellow"}"
+SPACESHIP_PYENV_USE_VENV="${SPACESHIP_PYENV_USE_VENV=false}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -20,14 +21,19 @@ SPACESHIP_PYENV_COLOR="${SPACESHIP_PYENV_COLOR="yellow"}"
 
 # Show current version of pyenv Python, including system.
 spaceship_pyenv() {
-  [[ $SPACESHIP_PYENV_SHOW == false ]] && return
+  # Do nothing if SHOW is false or pyenv is not installed
+  [[ $SPACESHIP_PYENV_SHOW == false ]] && spaceship::exists pyenv && return
 
   # Show pyenv python version only for Python-specific folders
   [[ -f requirements.txt ]] || [[ -n *.py(#qN^/) ]] || return
 
-  spaceship::exists pyenv || return # Do nothing if pyenv is not installed
-
-  local pyenv_status=${$(pyenv version-name 2>/dev/null)//:/ }
+  # Check if the current directory is running via Virtualenv
+  if  [[ $SPACESHIP_PYENV_USE_VENV && -n "$VIRTUAL_ENV" ]]
+  then
+    local pyenv_status=$(python -V | awk '{print $2}')
+  else
+    local pyenv_status=${$(pyenv version-name 2>/dev/null)//:/ }
+  fi
 
   spaceship::section \
     "$SPACESHIP_PYENV_COLOR" \

--- a/sections/pyenv.zsh
+++ b/sections/pyenv.zsh
@@ -21,11 +21,12 @@ SPACESHIP_PYENV_USE_VENV="${SPACESHIP_PYENV_USE_VENV=false}"
 
 # Show current version of pyenv Python, including system.
 spaceship_pyenv() {
-  # Do nothing if SHOW is false or pyenv is not installed
-  [[ $SPACESHIP_PYENV_SHOW == false ]] && spaceship::exists pyenv && return
+  [[ $SPACESHIP_PYENV_SHOW == false ]] && return
 
   # Show pyenv python version only for Python-specific folders
   [[ -f requirements.txt ]] || [[ -n *.py(#qN^/) ]] || return
+
+  spaceship::exists pyenv || return # Do nothing if pyenv is not installed
 
   # Check if the current directory is running via Virtualenv
   if  [[ $SPACESHIP_PYENV_USE_VENV && -n "$VIRTUAL_ENV" ]]

--- a/sections/pyenv.zsh
+++ b/sections/pyenv.zsh
@@ -13,7 +13,6 @@ SPACESHIP_PYENV_PREFIX="${SPACESHIP_PYENV_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREF
 SPACESHIP_PYENV_SUFFIX="${SPACESHIP_PYENV_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_PYENV_SYMBOL="${SPACESHIP_PYENV_SYMBOL="🐍 "}"
 SPACESHIP_PYENV_COLOR="${SPACESHIP_PYENV_COLOR="yellow"}"
-SPACESHIP_PYENV_USE_VENV="${SPACESHIP_PYENV_USE_VENV=false}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -28,13 +27,7 @@ spaceship_pyenv() {
 
   spaceship::exists pyenv || return # Do nothing if pyenv is not installed
 
-  # Check if the current directory is running via Virtualenv
-  if  [[ $SPACESHIP_PYENV_USE_VENV && -n "$VIRTUAL_ENV" ]]
-  then
-    local pyenv_status=$(python -V | awk '{print $2}')
-  else
-    local pyenv_status=${$(pyenv version-name 2>/dev/null)//:/ }
-  fi
+  local pyenv_status=${$(pyenv version-name 2>/dev/null)//:/ }
 
   spaceship::section \
     "$SPACESHIP_PYENV_COLOR" \

--- a/sections/python.zsh
+++ b/sections/python.zsh
@@ -1,0 +1,36 @@
+#
+# python
+#
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_PYTHON_SHOW="${SPACESHIP_PYTHON_SHOW=true}"
+SPACESHIP_PYTHON_PREFIX="${SPACESHIP_PYTHON_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_PYTHON_SUFFIX="${SPACESHIP_PYTHON_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_PYTHON_SYMBOL="${SPACESHIP_PYTHON_SYMBOL="🐍 "}"
+SPACESHIP_PYTHON_COLOR="${SPACESHIP_PYTHON_COLOR="220"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show current version of Python, including system.
+spaceship_python() {
+  [[ $SPACESHIP_PYTHON_SHOW == false ]] && return
+
+  # Show python python version only for Python-specific folders
+  [[ -f requirements.txt ]] || [[ -f Pipfile ]] || [[ -n *.py(#qN^/) ]] || return
+
+  spaceship::exists python || return # Do nothing if python is not installed
+
+  # Get current Python version
+  local python_status=$(python -V | awk '{print $2}')
+
+  spaceship::section \
+    "$SPACESHIP_PYTHON_COLOR" \
+    "$SPACESHIP_PYTHON_PREFIX" \
+    "${SPACESHIP_PYTHON_SYMBOL}${python_status}" \
+    "$SPACESHIP_PYTHON_SUFFIX"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -62,7 +62,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     aws           # Amazon Web Services section
     venv          # virtualenv section
     conda         # conda virtualenv section
-    pyenv         # Pyenv section
+    python        # Python section
     dotnet        # .NET section
     ember         # Ember.js section
     kubecontext   # Kubectl context section


### PR DESCRIPTION
#### Description

Currently, when you use `Pyenv` to manage python versions with `Virtualenv`, the prompt shows the `Pyenv` version, not the `Virtualenv` one, which is confusing.

This PR adds an option, `SPACESHIP_PYENV_USE_VENV`, which will enable a check if we are inside a `Virtualenv` and use its version instead `Pyenv`. This options defaults to `false`, which will not break any current setup.

This PR is related to PR #431.

#### Screenshot

![screen shot 2018-10-24 at 11 21 11](https://user-images.githubusercontent.com/289289/47440141-f8396a00-d783-11e8-99c7-c85d83207505.png)