### PR TITLE
acpi should take precedence in battery

### DIFF
--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -37,7 +37,20 @@ spaceship_battery() {
 
   local battery_data battery_percent battery_status battery_color
 
-  if spaceship::exists pmset; then
+  if spaceship::exists acpi; then
+    battery_data=$(acpi -b)
+
+    # Return if no battery
+    [[ -z $battery_data ]] && return
+
+	# If battery is 0% charge, battery likely doesn't exist.
+    if [[ $battery_data == 0 ]]; then
+        return
+	fi
+	
+    battery_percent="$( echo $battery_data | awk '{print $4}' )"
+    battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
+  elif spaceship::exists pmset; then
     battery_data=$(pmset -g batt)
 
     # Return if no internal battery
@@ -54,14 +67,6 @@ spaceship_battery() {
     battery_data=$(upower -i $battery)
     battery_percent="$( echo "$battery_data" | grep percentage | awk '{print $2}' )"
     battery_status="$( echo "$battery_data" | grep state | awk '{print $2}' )"
-  elif spaceship::exists acpi; then
-    battery_data=$(acpi -b)
-
-    # Return if no battery
-    [[ -z $battery_data ]] && return
-
-    battery_percent="$( echo $battery_data | awk '{print $4}' )"
-    battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
   else
     return
   fi

--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -37,20 +37,7 @@ spaceship_battery() {
 
   local battery_data battery_percent battery_status battery_color
 
-  if spaceship::exists acpi; then
-    battery_data=$(acpi -b)
-
-    # Return if no battery
-    [[ -z $battery_data ]] && return
-
-	# If battery is 0% charge, battery likely doesn't exist.
-    if [[ $battery_data == 0 ]]; then
-        return
-	fi
-	
-    battery_percent="$( echo $battery_data | awk '{print $4}' )"
-    battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
-  elif spaceship::exists pmset; then
+  if spaceship::exists pmset; then
     battery_data=$(pmset -g batt)
 
     # Return if no internal battery
@@ -58,6 +45,20 @@ spaceship_battery() {
 
     battery_percent="$( echo $battery_data | grep -oE '[0-9]{1,3}%' )"
     battery_status="$( echo $battery_data | awk -F '; *' 'NR==2 { print $2 }' )"
+  elif spaceship::exists acpi; then
+    battery_data=$(acpi -b)
+
+    # Return if no battery
+    [[ -z $battery_data ]] && return
+
+    battery_percent="$( echo $battery_data | awk '{print $4}' )"
+
+	# If battery is 0% charge, battery likely doesn't exist.
+    if [[ $battery_percent == "0%," ]]; then
+        return
+	fi
+	
+    battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
   elif spaceship::exists upower; then
     local battery=$(command upower -e | grep battery | head -1)
 

--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -54,9 +54,7 @@ spaceship_battery() {
     battery_percent="$( echo $battery_data | awk '{print $4}' )"
 
 	# If battery is 0% charge, battery likely doesn't exist.
-    if [[ $battery_percent == "0%," ]]; then
-        return
-	fi
+    [[ $battery_percent == "0%," ]] && return
 	
     battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
   elif spaceship::exists upower; then


### PR DESCRIPTION
#### Description

Shuffled battery section around, should fix issue #526. acpi seems to give a nicer output than upower and doesn't give a bunch of extra battery/peripheral devices that are hard to filter. If acpi returns 0% charge, the device is _likely_ a desktop without a battery.

Changes haven't been tested yet, testing yourself would be appreciated!

Fix #526