### PR TITLE
Add Terraform Workspace section

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Spaceship is a minimalistic, powerful and extremely customizable [Zsh][zsh-url] 
 * Current .NET SDK version, through dotnet-cli (`.NET`).
 * Current Ember.js version, through ember-cli (`🐹`).
 * Current Kubectl context (`☸️`).
+* Current Terraform workspace (`⬢`).
 * Package version, if there's is a package in current directory (`📦`).
 * Current battery level and status:
   * `⇡` - charging;

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -41,6 +41,7 @@ SPACESHIP_PROMPT_ORDER=(
   dotnet        # .NET section
   ember         # Ember.js section
   kubecontext   # Kubectl context section
+  tfworkspace   # Terraform workspace section
   exec_time     # Execution time
   line_sep      # Line break
   battery       # Battery level and status
@@ -471,6 +472,18 @@ Shows the active kubectl context.
 | `SPACESHIP_KUBECONTEXT_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Kubectl context section |
 | `SPACESHIP_KUBECONTEXT_SYMBOL` | `☸️·` | Character to be shown before Kubectl context |
 | `SPACESHIP_KUBECONTEXT_COLOR` | `cyan` | Color of Kubectl context section |
+
+### Terraform workspace (`tfworkspace`)
+
+Shows the active Terraform wokspace.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_TFWORKSPACE_SHOW` | `false` | Current Terraform workspace section |
+| `SPACESHIP_TFWORKSPACE_PREFIX` |  | Prefix before Terraform workspace section |
+| `SPACESHIP_TFWORKSPACE_SUFFIX` |  | Suffix after Terraform workspace section |
+| `SPACESHIP_TFWORKSPACE_SYMBOL` | `⬢ ` | Character to be shown before Terraform workspace |
+| `SPACESHIP_TFWORKSPACE_COLOR` | `#5c4ee5` | [Color](https://www.hashicorp.com/brand) of Terraform workspace section |
 
 ### Execution time (`exec_time`)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@
   * [.NET (dotnet)](/docs/Options.md#net-dotnet)
   * [Ember (ember)](/docs/Options.md#emberjs-ember)
   * [Kubectl context (kubecontext)](/docs/Options.md#kubectl-context-kubecontext)
+  * [Terraform workspace (tfworspace)](/docs/Options.md#terraform-workspace-tfworkspace)
   * [Execution time (exec_time)](/docs/Options.md#execution-time-exec_time)
   * [Battery (battery)](/docs/Options.md#battery-battery)
   * [Vi-mode (vi_mode)](/docs/Options.md#vi-mode-vi_mode)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -67,6 +67,7 @@ SPACESHIP_PROMPT_ORDER=(
   dotnet        # .NET section
   # ember       # Ember.js section (Disabled)
   kubecontext   # Kubectl context section
+  tfworkspace   # Terraform workspace section
   exec_time     # Execution time
   line_sep      # Line break
   battery       # Battery level and status

--- a/sections/tfworkspace.zsh
+++ b/sections/tfworkspace.zsh
@@ -1,0 +1,40 @@
+#
+# Terraform Workspaces
+#
+# Terraform automates the repetitive tasks of setting up cloud resources
+# Link: https://www.terraform.io
+#
+# This section shows you the current Terraform workspace
+# Link: https://www.terraform.io/docs/state/workspaces.html
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_TFWORKSPACE_SHOW="${SPACESHIP_TFWORKSPACE_SHOW=false}"
+SPACESHIP_TFWORKSPACE_PREFIX="${SPACESHIP_TFWORKSPACE_PREFIX=""}"
+SPACESHIP_TFWORKSPACE_SUFFIX="${SPACESHIP_TFWORKSPACE_SUFFIX=" "}"
+SPACESHIP_TFWORKSPACE_SYMBOL="${SPACESHIP_TFWORKSPACE_SYMBOL="⬢ "}"
+SPACESHIP_TFWORKSPACE_COLOR="${SPACESHIP_TFWORKSPACE_COLOR="#5c4ee5"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+spaceship_tfworkspace() {
+  [[ $SPACESHIP_TFWORKSPACE_SHOW == false ]] && return
+
+  spaceship::exists terraform || return
+
+  # Show Terraform Workspaces when exists
+  [[ -a .terraform/environment ]] || return
+
+  local terraform_workspace=$(cat .terraform/environment)
+  [[ -z $terraform_workspace ]] && return
+
+  spaceship::section \
+    "$SPACESHIP_TFWORKSPACE_COLOR" \
+    "$SPACESHIP_TFWORKSPACE_PREFIX" \
+    "$SPACESHIP_TFWORKSPACE_SYMBOL $terraform_workspace" \
+    "$SPACESHIP_TFWORKSPACE_SUFFIX"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -66,6 +66,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     dotnet        # .NET section
     ember         # Ember.js section
     kubecontext   # Kubectl context section
+    tfworkspace   # Terraform workspace section
     exec_time     # Execution time
     line_sep      # Line break
     battery       # Battery level and status


### PR DESCRIPTION
# Terraform Workspaces

#### Description

New section that shows the current Terraform [workspace](https://www.terraform.io/docs/state/workspaces.html) to avoid running `terraform apply` with a wrong workspace.

#### Demo

[![asciicast](https://asciinema.org/a/j7f1eSEa5q36xn1kSGFzd9WjP.png)](https://asciinema.org/a/j7f1eSEa5q36xn1kSGFzd9WjP)
