### PR TITLE
Use Zsh field splitting instead of awk

### DIFF
--- a/sections/docker.zsh
+++ b/sections/docker.zsh
@@ -33,7 +33,7 @@ spaceship_docker() {
   [[ -z $docker_version ]] && return
 
   # Split output on separator (-) and return the first element from resulting array
-  [[ $SPACESHIP_DOCKER_VERBOSE == false ]] && docker_version=${${(@s|-|)$(docker version -f "{{.Server.Version}}")}[1]}
+  [[ $SPACESHIP_DOCKER_VERBOSE == false ]] && docker_version=${${(@s|-|)docker_version}[1]}
 
   if [[ -n $DOCKER_MACHINE_NAME ]]; then
     docker_version+=" via ($DOCKER_MACHINE_NAME)"

--- a/sections/docker.zsh
+++ b/sections/docker.zsh
@@ -32,7 +32,7 @@ spaceship_docker() {
   local docker_version=$(docker version -f "{{.Server.Version}}" 2>/dev/null)
   [[ -z $docker_version ]] && return
 
-  [[ $SPACESHIP_DOCKER_VERBOSE == false ]] && docker_version=$(echo ${docker_version} | awk -F\- '{ print $1 }')
+  [[ $SPACESHIP_DOCKER_VERBOSE == false ]] && docker_version=${${(@s|-|)$(docker version -f "{{.Server.Version}}")}[1]}
 
   if [[ -n $DOCKER_MACHINE_NAME ]]; then
     docker_version+=" via ($DOCKER_MACHINE_NAME)"

--- a/sections/docker.zsh
+++ b/sections/docker.zsh
@@ -32,6 +32,7 @@ spaceship_docker() {
   local docker_version=$(docker version -f "{{.Server.Version}}" 2>/dev/null)
   [[ -z $docker_version ]] && return
 
+  # Split output on separator (-) and return the first element from resulting array
   [[ $SPACESHIP_DOCKER_VERBOSE == false ]] && docker_version=${${(@s|-|)$(docker version -f "{{.Server.Version}}")}[1]}
 
   if [[ -n $DOCKER_MACHINE_NAME ]]; then

--- a/sections/php.zsh
+++ b/sections/php.zsh
@@ -27,7 +27,7 @@ spaceship_php() {
 
   spaceship::exists php || return
 
-  local php_version=$(php -v 2>&1 | grep --color=never -oe "^PHP\s*[0-9.]\+" | awk '{print $2}')
+  local php_version=${${(@s|-|)$(php -v 2>&1)[2]}[1]}
 
   spaceship::section \
     "$SPACESHIP_PHP_COLOR" \

--- a/sections/php.zsh
+++ b/sections/php.zsh
@@ -27,9 +27,7 @@ spaceship_php() {
 
   spaceship::exists php || return
 
-  # 1. Split output to array on space and return first element
-  # 2. Split output from step 1 on (-) and return second element
-  local php_version=${${(@s|-|)$(php -v 2>&1)[2]}[1]}
+  local php_version=$(php -v 2>&1 | grep --color=never -oe "^PHP\s*[0-9.]\+" | awk '{print $2}')
 
   spaceship::section \
     "$SPACESHIP_PHP_COLOR" \

--- a/sections/php.zsh
+++ b/sections/php.zsh
@@ -27,6 +27,8 @@ spaceship_php() {
 
   spaceship::exists php || return
 
+  # 1. Split output to array on space and return first element
+  # 2. Split output from step 1 on (-) and return second element
   local php_version=${${(@s|-|)$(php -v 2>&1)[2]}[1]}
 
   spaceship::section \

--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -34,6 +34,7 @@ spaceship_ruby() {
   elif spaceship::exists rbenv; then
     ruby_version=$(rbenv version-name)
   elif spaceship::exists asdf; then
+    # split output on space and return first element
     ruby_version=${$(asdf current ruby)[1]}
   else
     return

--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -34,7 +34,7 @@ spaceship_ruby() {
   elif spaceship::exists rbenv; then
     ruby_version=$(rbenv version-name)
   elif spaceship::exists asdf; then
-    ruby_version=$(asdf current ruby | awk '{print $1}')
+    ruby_version=${$(asdf current ruby)[1]}
   else
     return
   fi


### PR DESCRIPTION
Dropping few of the `awk` commands to reduce calling external commands. Making use of the wonderful Zsh field splitting. There are few more places we could optimize with native code like in`battery` section. Splitting should be similar, But currently don't have setup to test changes.
