### PR TITLE
Fix "bad math expression" for battery with UPS

### DIFF
--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -38,10 +38,10 @@ spaceship_battery() {
   local battery_data battery_percent battery_status battery_color
 
   if spaceship::exists pmset; then
-    battery_data=$(pmset -g batt)
+    battery_data=$(pmset -g batt | grep "InternalBattery")
 
     # Return if no internal battery
-    [[ -z $(echo $battery_data | grep "InternalBattery") ]] && return
+    [[ -z "$battery_data" ]] && return
 
     battery_percent="$( echo $battery_data | grep -oE '[0-9]{1,3}%' )"
     battery_status="$( echo $battery_data | awk -F '; *' 'NR==2 { print $2 }' )"


### PR DESCRIPTION
Fixes #245 `spaceship_battery:56: bad math expression: operator expected at '100'` if multiple battery multiple are reported (on macOS, at least). 
Happens when pmset reports secondary charge due to UPS.

Instead of only testing for existence of "InternalBattery" in `pmset -g batt` result, will filter this row from the beginning so no other charges are combined into the result.
