### PR TITLE
Recognize pyproject.toml when showing pyenv section

### DIFF
--- a/sections/pyenv.zsh
+++ b/sections/pyenv.zsh
@@ -23,7 +23,7 @@ spaceship_pyenv() {
   [[ $SPACESHIP_PYENV_SHOW == false ]] && return
 
   # Show pyenv python version only for Python-specific folders
-  [[ -f requirements.txt ]] || [[ -n *.py(#qN^/) ]] || [[ -f pyproject.toml ]] || return
+  [[ -f requirements.txt || -f pyproject.toml || -n *.py(#qN^/) ]] || return
 
   spaceship::exists pyenv || return # Do nothing if pyenv is not installed
 

--- a/sections/pyenv.zsh
+++ b/sections/pyenv.zsh
@@ -23,7 +23,7 @@ spaceship_pyenv() {
   [[ $SPACESHIP_PYENV_SHOW == false ]] && return
 
   # Show pyenv python version only for Python-specific folders
-  [[ -f requirements.txt ]] || [[ -n *.py(#qN^/) ]] || return
+  [[ -f requirements.txt ]] || [[ -n *.py(#qN^/) ]] || [[ -f pyproject.toml ]] || return
 
   spaceship::exists pyenv || return # Do nothing if pyenv is not installed
 


### PR DESCRIPTION
#### Description

With this PR, the prompt shows *pyenv* section whenever it finds a `pyproject.toml` file in the cwd. This file belongs to python projects (see [PEP-518/#specification](https://www.python.org/dev/peps/pep-0518/#specification) and tools like [Poetry](https://github.com/sdispater/poetry) use the file to store the build instructions and requirements

#### Screenshot

![spaceship-prompt](https://user-images.githubusercontent.com/8370058/48092103-4bbea580-e1d1-11e8-9965-c85d7ff674fb.png)


