### PR TITLE
Update package.zsh

### DIFF
--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -29,7 +29,7 @@ spaceship_package() {
   spaceship::exists npm || return
 
   # Grep and cut out package version
-  local package_version=$(grep -E '"version": "v?([0-9]+\.){1,}' package.json | cut -d\" -f4 2> /dev/null)
+  local package_version=$(grep -E '"version": "v?([0-9]+\.){1,}' -m 1 package.json | cut -d\" -f4 2> /dev/null)
 
   # Handle version not found
   if [ ! "$package_version" ]; then


### PR DESCRIPTION
#### Description

Stop looking for the version number after the first result.
In nativescript projects `package.json` file has more than one version which brake the line in the terminal

#### Screenshot

![screenshot from 2018-11-09 12-49-38](https://user-images.githubusercontent.com/19766186/48258971-2fb04380-e41f-11e8-8795-4d4364459b5f.png)
![screenshot from 2018-11-09 12-49-21](https://user-images.githubusercontent.com/19766186/48258969-2fb04380-e41f-11e8-9500-07253166a76b.png)