### PR TITLE
Add semver utils

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -254,3 +254,64 @@ arr3=('c' 'd' 'e')
 spaceship::union $arr1 $arr2 $arr3
 #> a b c d e
 ```
+
+## spaceship::parse_semver <semver>
+
+This utility parses a [semver](https://semver.org) into an associative array. Empty values are marked with a `*`.
+
+### Arguments
+
+1. `semver` _Required_ — semantic version to parse.
+
+### Example
+
+```zsh
+spaceship::parse_semver 3.2.1-alpha.2+20160130175002
+#> patch 1 prere alpha.2 major 3 build 20160130175002 minor 2
+$ spaceship::parse_semver 3.2.1
+#> patch 1 prere * major 3 build * minor 2
+```
+
+As this outputs an associative array, to use the output in another function, you'll need to declare an associative array.
+
+```zsh
+spaceship::print_semver() {
+  typeset -A semver
+  semver=($(spaceship::parse_semver $1))
+  echo "major:       ${semver[major]}"
+  echo "minor:       ${semver[minor]}"
+  echo "patch:       ${semver[patch]}"
+  echo "pre-release: ${semver[prere]}"
+  echo "build:       ${semver[build]}"
+}
+```
+
+## spaceship::compare_semver <semver1> <semver2>
+
+Compare two [semvers](https://semver.org).
+
+Outputs
+
+* -1 if semver1 < semver2
+* 0 if semver1 = semver2
+* 1 if semver1 > semver2
+
+### Arguments
+
+1. `semver1` _Required_ — first semantic version to compare.
+2. `semver2` _Required_ — second semantic version to compare.
+
+### Example
+
+```zsh
+spaceship::compare_semver 3.2.1 3.2.1
+#> 0
+spaceship::compare_semver 0.18.0 0.19.0
+#> -1
+spaceship::compare_semver 3.2.1 3.1.4
+#> 1
+spaceship::compare_semver 3.2.1 3.2.1-alpha
+#> 1
+spaceship::compare_semver 3.2.1-alpha+1 3.2.1-alpha+2
+#> 0
+```

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -77,3 +77,145 @@ spaceship::union() {
   typeset -U sections=("$@")
   echo $sections
 }
+
+# Parse a semver (https://semver.org) into an associative array.
+# Empty values are marked with a '*'.
+# USAGE:
+#   spaceship::parse_semver <semver>
+# EXAMPLE:
+#   $ spaceship::parse_semver 3.2.1-alpha.2+20160130175002
+#   > patch 1 prere alpha.2 major 3 build 20160130175002 minor 2
+#   $ spaceship::parse_semver 3.2.1
+#   > patch 1 prere * major 3 build * minor 2
+spaceship::parse_semver() {
+  local version=$1
+  local semver_regex="^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-([0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*))?(\\+([0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*))?$"
+  if [[ "$version" =~ $semver_regex ]]; then
+    typeset -A parsed
+    parsed[major]="${match[1]}"
+    parsed[minor]="${match[2]}"
+    parsed[patch]="${match[3]}"
+    parsed[prere]="${match[5]}"
+    parsed[build]="${match[8]}"
+    if [[ -z "${parsed[prere]}" ]]; then
+      parsed[prere]='*'
+    fi
+    if [[ -z "${parsed[build]}" ]]; then
+      parsed[build]="*"
+    fi
+    echo "${(kv)parsed}"
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Compare two semvers (https://semver.org)
+# Outputs
+#   -1 if semver1 < semver2
+#    0 if semver1 = semver2
+#    1 if semver1 > semver2
+# USAGE:
+#   spaceship::compare_semver <semver1> <semver2>
+# EXAMPLE:
+#   $ spaceship::compare_semver 3.2.1 3.2.1
+#   > 0
+#   $ spaceship::compare_semver 3.2.1 3.3.1
+#   > -1
+#   $ spaceship::compare_semver 8.2.1 3.3.1
+#   > 1
+#   spaceship::compare_semver 3.2.1 3.2.1-alpha
+#   > 1
+#   spaceship::compare_semver 3.2.1-alpha+1 3.2.1-alpha+2
+#   > 0
+spaceship::compare_semver() {
+  typeset -A version1 version2
+  version1=($(spaceship::parse_semver $1))
+  version2=($(spaceship::parse_semver $2))
+
+  # Stop if there were parse errors
+  [[ -z "$version1" || -z "$version2" ]] && return 1
+
+  # Major, minor and patch MUST be compared numericaly in order
+  for i in major minor patch; do
+    local v1=${version1[$i]}
+    local v2=${version2[$i]}
+    if (( v1 < v2 )); then
+      echo -1
+      return 0
+    elif (( v1 > v2 )); then
+      echo 1
+      return 0
+    fi
+  done
+
+  # Pre-release MUST have lower precedence than a normal version
+  if [[ "${version1[prere]}" != "*" && "${version2[prere]}" == "*" ]]; then
+    echo -1
+    return 0
+  elif [[ "${version1[prere]}" == "*" && "${version2[prere]}" != "*" ]]; then
+    echo 1
+    return 0
+  fi
+
+  # Pre-release MUST compare each dot separated identifier from left to right
+  # until a difference is found
+  IFS='.' read -r -A prere1 <<< "${version1[prere]}"
+  IFS='.' read -r -A prere2 <<< "${version2[prere]}"
+  local max_len=$(( ${#prere1} > ${#prere2} ? ${#prere1} : ${#prere2} ))
+  for (( i = 1; i <= $max_len; i++ )); do
+    local p1="${prere1[$i]}"
+    local p2="${prere2[$i]}"
+
+    # A smaller set of pre-release fields MUST have a lower precedence than a
+    # larger set, if all of the preceding identifiers are equal
+    if [[ "$p1" == "" && "$p2" != "" ]]; then
+      echo -1
+      return 0
+    elif [[ "$p1" != "" && "$p2" == "" ]]; then
+      echo 1
+      return 0
+    fi
+
+    local num_regex='^[0-9]+$'
+    local p1_is_num=$([[ "$p1" =~ "$num_regex" ]] && echo true || echo false)
+    local p2_is_num=$([[ "$p2" =~ "$num_regex" ]] && echo true || echo false)
+
+    # Identifiers consisting of only digits MUST be compared numerically
+    if [[ $p1_is_num == true && $p2_is_num == true ]]; then
+      if (( p1 < p2 )); then
+        echo -1
+        return 0
+      elif (( p1 > p2 )); then
+        echo 1
+        return 0
+      fi
+    fi
+
+    # Identifiers with letters or hyphens MUST be compared lexically in ASCII
+    # sort order
+    if [[ $p1_is_num == false && $p2_is_num == false ]]; then
+      if [[ $p1 < $p2 ]]; then
+        echo -1
+        return 0
+      elif [[ $p1 > $p2 ]]; then
+        echo 1
+        return 0
+      fi
+    fi
+
+    # Numeric identifiers MUST always have lower precedence than
+    # non-numeric identifiers
+    if [[ $p1_is_num == true && $p2_is_num == false ]]; then
+      echo -1
+      return 0
+    elif [[ $p1_is_num == false && $p2_is_num == true ]]; then
+      echo 1
+      return 0
+    fi
+  done
+
+  # Build metadata SHOULD be ignored
+
+  echo 0
+}

--- a/tests/utils.test.zsh
+++ b/tests/utils.test.zsh
@@ -106,6 +106,81 @@ test_union() {
   assertEquals "union of arrays" "$expected" "$actual"
 }
 
+test_parse_semver() {
+  spaceship::parse_semver asdf
+
+  assertFalse "return false when parsing invalid semver" "$?"
+
+  typeset -A expected actual
+
+  expected=(major 3 minor 2 patch 1 prere alpha.2 build 20160130175002)
+  actual=($(spaceship::parse_semver 3.2.1-alpha.2+20160130175002))
+
+  assertEquals "parse full semver" "${(kv)expected}" "${(kv)actual}"
+
+  expected=(major 3 minor 2 patch 1 prere '*' build '*')
+  actual=($(spaceship::parse_semver 3.2.1))
+
+  assertEquals "parse base semver" "${(kv)expected}" "${(kv)actual}"
+
+  expected=(major 3 minor 2 patch 1 prere '*' build 1.2)
+  actual=($(spaceship::parse_semver 3.2.1+1.2))
+
+  assertEquals "parse semver without prerelease" "${(kv)expected}" "${(kv)actual}"
+
+  expected=(major 3 minor 2 patch 1 prere alpha.2.3.4 build '*')
+  actual=($(spaceship::parse_semver 3.2.1-alpha.2.3.4))
+
+  assertEquals "parse semver without build" "${(kv)expected}" "${(kv)actual}"
+}
+
+test_compare_semver() {
+  local expected=0
+  local actual="$(spaceship::compare_semver 1.2.3 1.2.3)"
+
+  assertEquals "identical versions" "$expected" "$actual"
+
+  local expected=1
+  local actual="$(spaceship::compare_semver 0.19.0 0.18.1)"
+
+  assertEquals "semver1 greater than semver2" "$expected" "$actual"
+
+  local expected=-1
+  local actual="$(spaceship::compare_semver 1.2.3 1.2.4)"
+
+  assertEquals "semver1 less than semver2" "$expected" "$actual"
+
+  # For testing the pre-releases, this list is strictly increasing in value
+  local versions=(
+    '1.0.0-alpha'
+    '1.0.0-alpha.1'
+    '1.0.0-alpha.beta'
+    '1.0.0-beta'
+    '1.0.0-beta.2'
+    '1.0.0-beta.11'
+    '1.0.0-rc.1'
+    '1.0.0'
+  )
+  for (( i = 1; i <= ${#versions} - 1; i++ )); do
+    local v1="${versions[$i]}"
+    local v2="${versions[(( i + 1 ))]}"
+
+    local expected=-1
+    local actual="$(spaceship::compare_semver ${v1} ${v2})"
+
+    assertEquals "pre-release ${v1} less than ${v2}" "$expected" "$actual"
+  done
+
+  local expected=0
+  local actual="$(spaceship::compare_semver 1.2.3+1 1.2.3+2)"
+
+  assertEquals "ignore build number" "$expected" "$actual"
+
+  local actual=$(spaceship::compare_semver 1.2.3 1.23)
+
+  assertFalse "return false on parse error" $actual
+}
+
 # ------------------------------------------------------------------------------
 # SHUNIT2
 # Run tests with shunit2


### PR DESCRIPTION
#### Description

Split from https://github.com/denysdovhan/spaceship-prompt/pull/527#issuecomment-431035184

Adds utility functions `spaceship::compare_semver` and `spaceship::parse_semver` to work with semantic versions (https://semver.org).
