### PR TITLE
Allow mock elm version to be changed

### DIFF
--- a/tests/elm.test.zsh
+++ b/tests/elm.test.zsh
@@ -11,6 +11,7 @@ SHUNIT_PARENT=$0
 oneTimeSetUp() {
   export TERM="xterm-256color"
   export PATH=$PWD/tests/stubs:$PATH
+  export SPACESHIP_MOCK_ELM_VERSION="0.20.0"
 
   SPACESHIP_PROMPT_FIRST_PREFIX_SHOW=true
   SPACESHIP_PROMPT_ADD_NEWLINE=false

--- a/tests/stubs/elm
+++ b/tests/stubs/elm
@@ -1,3 +1,3 @@
 #!/usr/bin/env zsh
 
-echo 0.20.0
+echo "$SPACESHIP_MOCK_ELM_VERSION"


### PR DESCRIPTION
#### Description

Split from https://github.com/denysdovhan/spaceship-prompt/pull/527#issuecomment-431035184

Allows configuring the mock for testing different versions of elm with the `SPACESHIP_MOCK_ELM_VERSION` variable.

