### PR TITLE
Add current Kubernetes namespace to kube_context

### DIFF
--- a/sections/kubecontext.zsh
+++ b/sections/kubecontext.zsh
@@ -27,7 +27,10 @@ spaceship_kubecontext() {
 
   spaceship::exists kubectl || return
 
-  local kube_context=$(kubectl config current-context 2>/dev/null)
+  local kube_cluster=$(kubectl config current-context 2>/dev/null)
+  local kube_ns=$(kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)
+  local kube_ns="${kube_ns:-default}"
+  local kube_context="${kube_cluster}:${kube_ns}"
 
   [[ -z $kube_context ]] && return
 


### PR DESCRIPTION
#### Description

Adds the name of the current Kubernetes namespace to the `kube_context` prompt.

#### Screenshot

<img width="606" alt="screenshot 2018-11-20 at 09 34 29" src="https://user-images.githubusercontent.com/752513/48758192-ec1fca00-eca7-11e8-86e1-3c5b56a8d812.png">

