### PR TITLE
Redirect acpi error to null

### DIFF
--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -46,7 +46,7 @@ spaceship_battery() {
     battery_percent="$( echo $battery_data | grep -oE '[0-9]{1,3}%' )"
     battery_status="$( echo $battery_data | awk -F '; *' 'NR==2 { print $2 }' )"
   elif spaceship::exists acpi; then
-    battery_data=$(acpi -b)
+    battery_data=$(acpi -b 2>/dev/null)
 
     # Return if no battery
     [[ -z $battery_data ]] && return


### PR DESCRIPTION
Devices without battery would produce error, which have to redirected.
Else it will printed to prompt.

![acpi error on prompt](https://user-images.githubusercontent.com/10276208/48915608-4e91e980-eea5-11e8-901b-7c46cb690fff.png)
