### PR TITLE
Kubernetes namespace display can be turned off

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -479,6 +479,7 @@ Shows the active kubectl context, which consists of a cluster name and, when wor
 | `SPACESHIP_KUBECONTEXT_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Kubectl context section |
 | `SPACESHIP_KUBECONTEXT_SYMBOL` | `☸️·` | Character to be shown before Kubectl context |
 | `SPACESHIP_KUBECONTEXT_COLOR` | `cyan` | Color of Kubectl context section |
+| `SPACESHIP_KUBECONTEXT_NAMESPACE_SHOW` | `true` | Should namespace be also displayed |
 
 ### Terraform workspace (`terraform`)
 

--- a/sections/kubecontext.zsh
+++ b/sections/kubecontext.zsh
@@ -16,6 +16,7 @@ SPACESHIP_KUBECONTEXT_SUFFIX="${SPACESHIP_KUBECONTEXT_SUFFIX="$SPACESHIP_PROMPT_
 # See: https://github.com/denysdovhan/spaceship-prompt/pull/432
 SPACESHIP_KUBECONTEXT_SYMBOL="${SPACESHIP_KUBECONTEXT_SYMBOL="☸️  "}"
 SPACESHIP_KUBECONTEXT_COLOR="${SPACESHIP_KUBECONTEXT_COLOR="cyan"}"
+SPACESHIP_KUBECONTEXT_NAMESPACE_SHOW="${SPACESHIP_KUBECONTEXT_NAMESPACE_SHOW=true}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -30,8 +31,10 @@ spaceship_kubecontext() {
   local kube_context=$(kubectl config current-context 2>/dev/null)
   [[ -z $kube_context ]] && return
 
-  local kube_namespace=$(kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)
-  [[ -n $kube_namespace && "$kube_namespace" != "default" ]] && kube_context="$kube_context ($kube_namespace)"
+  if [[ $SPACESHIP_KUBECONTEXT_NAMESPACE_SHOW == true ]]; then
+    local kube_namespace=$(kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)
+    [[ -n $kube_namespace && "$kube_namespace" != "default" ]] && kube_context="$kube_context ($kube_namespace)"
+  fi
 
   spaceship::section \
     "$SPACESHIP_KUBECONTEXT_COLOR" \


### PR DESCRIPTION
#### Description

Adds a config flag to the `kubecontext` section to control whether namespace is displayed or not.

By default, original behavior is conserved and display is on.

By setting `SPACESHIP_KUBECONTEXT_NAMESPACE_SHOW=false` in .zshrc it is possible to get rid of this display in case namespace is not something one is interested in. This also avoids running `kubectl config view --minify --output 'jsonpath={..namespace}'` command.

#### Screenshot

![screen shot 2018-11-30 at 11 11 27](https://user-images.githubusercontent.com/9551921/49279657-c0af9300-f490-11e8-9927-8b530338648e.png)

