### PR TITLE
SPACESHIP_KUBECONTEXT_NAMESPACE_SHOW should be empty

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -480,7 +480,7 @@ Shows the active kubectl context, which consists of a cluster name and, when wor
 | `SPACESHIP_KUBECONTEXT_SYMBOL` | `☸️·` | Character to be shown before Kubectl context |
 | `SPACESHIP_KUBECONTEXT_COLOR` | `cyan` | Color of Kubectl context section |
 | `SPACESHIP_KUBECONTEXT_NAMESPACE_SHOW` | `true` | Should namespace be also displayed |
-| `SPACESHIP_KUBECONTEXT_COLOR_GROUPS` | `( )` | _Array_ of pairs of colors and match patterns, empty by default |
+| `SPACESHIP_KUBECONTEXT_COLOR_GROUPS` | ` ` | _Array_ of pairs of colors and match patterns, empty by default |
 
 **Color Groups:** To set the section to a different color based on context or namespace, you can define an array of pair values in which the first value of a pair is a color name to use and the second value is a regular expression pattern to match against the section text (context name and/or namespace). The first matched pattern will determine the color, so list order can be used to prioritize patterns.
 

--- a/sections/kubecontext.zsh
+++ b/sections/kubecontext.zsh
@@ -39,19 +39,18 @@ spaceship_kubecontext() {
 
   # Apply custom color to section if $kube_context matches a pattern defined in SPACESHIP_KUBECONTEXT_COLOR_GROUPS array.
   # See Options.md for usage example.
-  local 'section_color' 'i' 'color' 'pattern'
   local len=${#SPACESHIP_KUBECONTEXT_COLOR_GROUPS[@]}
-
-  if [[ $len -gt 1 ]]; then
-    for ((i = 1; i <= $len; i+=2)); do
-      color="${SPACESHIP_KUBECONTEXT_COLOR_GROUPS[$i]}"
-      pattern="${SPACESHIP_KUBECONTEXT_COLOR_GROUPS[$i+1]}"
-      if [[ "$kube_context" =~ "$pattern" ]]; then
-        section_color=$color
-        break
-      fi
-    done
-  fi
+  local it_to=$((len / 2))
+  local 'section_color' 'i'
+  for ((i = 1; i <= $it_to; i++)); do
+    local idx=$(((i - 1) * 2))
+    local color="${SPACESHIP_KUBECONTEXT_COLOR_GROUPS[$idx + 1]}"
+    local pattern="${SPACESHIP_KUBECONTEXT_COLOR_GROUPS[$idx + 2]}"
+    if [[ "$kube_context" =~ "$pattern" ]]; then
+      section_color=$color
+      break
+    fi
+  done
 
   [[ -z "$section_color" ]] && section_color=$SPACESHIP_KUBECONTEXT_COLOR
 

--- a/sections/kubecontext.zsh
+++ b/sections/kubecontext.zsh
@@ -17,7 +17,7 @@ SPACESHIP_KUBECONTEXT_SUFFIX="${SPACESHIP_KUBECONTEXT_SUFFIX="$SPACESHIP_PROMPT_
 SPACESHIP_KUBECONTEXT_SYMBOL="${SPACESHIP_KUBECONTEXT_SYMBOL="☸️  "}"
 SPACESHIP_KUBECONTEXT_COLOR="${SPACESHIP_KUBECONTEXT_COLOR="cyan"}"
 SPACESHIP_KUBECONTEXT_NAMESPACE_SHOW="${SPACESHIP_KUBECONTEXT_NAMESPACE_SHOW=true}"
-SPACESHIP_KUBECONTEXT_COLOR_GROUPS=(${SPACESHIP_KUBECONTEXT_COLOR_GROUPS=()})
+SPACESHIP_KUBECONTEXT_COLOR_GROUPS=(${SPACESHIP_KUBECONTEXT_COLOR_GROUPS=})
 
 # ------------------------------------------------------------------------------
 # Section
@@ -42,14 +42,16 @@ spaceship_kubecontext() {
   local 'section_color' 'i' 'color' 'pattern'
   local len=${#SPACESHIP_KUBECONTEXT_COLOR_GROUPS[@]}
 
-  for ((i = 1; i <= $len; i+=2)); do
-    color="${SPACESHIP_KUBECONTEXT_COLOR_GROUPS[$i]}"
-    pattern="${SPACESHIP_KUBECONTEXT_COLOR_GROUPS[$i+1]}"
-    if [[ "$kube_context" =~ "$pattern" ]]; then
-      section_color=$color
-      break
-    fi
-  done
+  if [[ $len -gt 1 ]]; then
+    for ((i = 1; i <= $len; i+=2)); do
+      color="${SPACESHIP_KUBECONTEXT_COLOR_GROUPS[$i]}"
+      pattern="${SPACESHIP_KUBECONTEXT_COLOR_GROUPS[$i+1]}"
+      if [[ "$kube_context" =~ "$pattern" ]]; then
+        section_color=$color
+        break
+      fi
+    done
+  fi
 
   [[ -z "$section_color" ]] && section_color=$SPACESHIP_KUBECONTEXT_COLOR
 


### PR DESCRIPTION
Correctly initializes unset SPACESHIP_KUBECONTEXT_NAMESPACE_SHOW to be empty instead of a "()" string


Fix #587
