### PR TITLE
Add swift package tools-version to prompt

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# You can add one username per supported platform and one custom link
+patreon: denysdovhan
+open_collective: # Replace with your Open Collective username
+ko_fi: # Replace with your Ko-fi username
+custom: # Replace with your custom donation URL

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Spaceship is a minimalistic, powerful and extremely customizable [Zsh][zsh-url] 
 - Current Ruby version, through rvm/rbenv/chruby/asdf (`💎`).
 - Current Elm version (`🌳`)
 - Current Elixir version, through kiex/exenv/elixir (`💧`).
-- Current Swift version, through swiftenv (`🐦`).
+- Current Swift version, through swiftenv or Swift Package Manager (`🐦`).
 - Current Xcode version, through xenv (`🛠`).
 - Current Go version (`🐹`).
 - Current PHP version (`🐘`).

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Still struggling? Please, [file an issue](https://github.com/denysdovhan/spacesh
 Here's a list of related projects that have been inspired by Spaceship ZSH.
 
 - [**matchai/spacefish**](https://github.com/matchai/spacefish) - A port of Spaceship ZSH for fish shell intending to achieve complete feature parity.
+- [**starship/starship**](https://github.com/starship/starship) - A blazing-fast, cross-shell prompt written in Rust, heavily inspired by Spaceship ZSH.
 
 ## Team
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ zgen load denysdovhan/spaceship-prompt spaceship
 Use this command in your `.zshrc` to load Spaceship as prompt theme:
 
 ```
-zplug denysdovhan/spaceship-prompt, use:spaceship.zsh, from:github, as:theme
+zplug "denysdovhan/spaceship-prompt", use:spaceship.zsh, from:github, as:theme
 ```
 
 ### Linux package manager

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Spaceship is a minimalistic, powerful and extremely customizable [Zsh][zsh-url] 
 * Current Ruby version, through rvm/rbenv/chruby/asdf (`💎`).
 * Current Elm version (`🌳`)
 * Current Elixir version, through kiex/exenv/elixir (`💧`).
-* Current Swift version, through swiftenv (`🐦`).
+* Current Swift version, through swiftenv or SPM (`🐦`).
 * Current Xcode version, through xenv (`🛠`).
 * Current Go version (`🐹`).
 * Current PHP version (`🐘`).

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -547,7 +547,7 @@ By default, Battery section is shown only if battery level is below `SPACESHIP_B
 | :------- | :-----: | ------- |
 | `SPACESHIP_BATTERY_SHOW` | `true` | Show battery section or not (`true`, `false`, `always` or `charged`) |
 | `SPACESHIP_BATTERY_PREFIX` | ` ` | Prefix before battery section |
-| `SPACESHIP_BATTERY_SUFFIX` | `SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after battery section |
+| `SPACESHIP_BATTERY_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after battery section |
 | `SPACESHIP_BATTERY_SYMBOL_CHARGING` | `⇡` | Character to be shown if battery is charging |
 | `SPACESHIP_BATTERY_SYMBOL_DISCHARGING` | `⇣` | Character to be shown if battery is discharging |
 | `SPACESHIP_BATTERY_SYMBOL_FULL` | `•` | Character to be shown if battery is full |

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -309,11 +309,16 @@ Shows current version of Xcode. Local version has more priority than global.
 
 ### Swift (`swift`)
 
-Shows current version of Swift. Local version has more priority than global.
+Shows current version of Swift using [swiftenv] or [swift-package].
+
+* **swiftenv** — Local version has more priority than global and is shown only in directories that contain `.swift-version` or `Package.swift`.
+* **swift-package** — Does not support global swift version. Read local swift versions using `swift package tools-version` in directories that contain `Package.swift`.
+
+[swift-package] is not used, unless [swiftenv] is unavailable.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
-| `SPACESHIP_SWIFT_SHOW_LOCAL` | `true` | Current local Swift version based on [swiftenv] |
+| `SPACESHIP_SWIFT_SHOW_LOCAL` | `true` | Current local Swift version based on [swiftenv] or [swift-package] |
 | `SPACESHIP_SWIFT_SHOW_GLOBAL` | `false` | Global Swift version based on [swiftenv] |
 | `SPACESHIP_SWIFT_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Swift section |
 | `SPACESHIP_SWIFT_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix to be shown before the Swift section |

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -31,7 +31,7 @@ spaceship::is_git() {
 spaceship::is_hg() {
   local root="$(pwd -P)"
 
-  while [ $root ] && [ ! -d $root/.hg ]; do
+  while [ "$root" ] && [ ! -d "$root/.hg" ]; do
     root="${root%/*}"
   done
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaceship-prompt",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "A Zsh prompt for Astronauts.",
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaceship-prompt",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "A Zsh prompt for Astronauts.",
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaceship-prompt",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "description": "A Zsh prompt for Astronauts.",
   "files": [
     "lib",

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -80,13 +80,20 @@ main() {
 
   # Remove Spaceship from .zshrc
   if grep -q "spaceship" "$ZSHRC"; then
-    info "Removing Spaceship from ~/.zshrc"
-    # Remove enabling statements from ~/.zshrc
-    sed -i '' '/^# Set Spaceship ZSH as a prompt$/d' $ZSHRC
-    sed -i '' '/^autoload -U promptinit; promptinit$/d' $ZSHRC
-    sed -i '' '/^prompt spaceship$/d' $ZSHRC
-    # Remove Spaceship configuration
-    sed -i '' '/^SPACESHIP_.*$/d' $ZSHRC
+    read "answer?Would you like to remove you Spaceship ZSH configuration from .zshrc? (y/N)"
+    if [[ 'y' == ${answer:l} ]]; then
+      info "Removing Spaceship from ~/.zshrc"
+      # Remove enabling statements from ~/.zshrc
+      # and remove Spaceship configuration
+      # Note: SPACESHIP_RPROMPT_ORDER and SPACESHIP_PROMPT_ORDER configuration may have multiple lines
+      # which are grouped by `(`, `)`
+      sed '/^# Set Spaceship ZSH as a prompt$/d' "$ZSHRC" | \
+      sed '/^autoload -U promptinit; promptinit$/d' | \
+      sed '/^prompt spaceship$/d' | \
+      sed  -E '/^SPACESHIP_R?PROMPT_ORDER=\([^)]*$/,/^[^(]*)/d' | \
+      sed '/^SPACESHIP_.*$/d' > "$ZSHRC.bak" && \
+      mv -- "$ZSHRC.bak" "$ZSHRC"
+    fi
   else
     warn "Spaceship configuration not found in ~/.zshrc!"
   fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -98,7 +98,7 @@ main() {
     warn "Spaceship configuration not found in ~/.zshrc!"
   fi
 
-  success "Done! Spaceship installation have to be removed!"
+  success "Done! Spaceship installation has been removed!"
   success "Please, reload your terminal."
 }
 

--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -56,7 +56,7 @@ spaceship_battery() {
 	# If battery is 0% charge, battery likely doesn't exist.
     [[ $battery_percent == "0%," ]] && return
 
-    battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
+    battery_status="$( echo $battery_data | awk '{print tolower($3)}' | tr -d ',')"
   elif spaceship::exists upower; then
     local battery=$(command upower -e | grep battery | head -1)
 

--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -44,7 +44,7 @@ spaceship_battery() {
     [[ -z "$battery_data" ]] && return
 
     battery_percent="$( echo $battery_data | grep -oE '[0-9]{1,3}%' )"
-    battery_status="$( echo $battery_data | awk -F '; *' 'NR==2 { print $2 }' )"
+    battery_status="$( echo $battery_data | awk -F '; *' '{ print $2 }' )"
   elif spaceship::exists acpi; then
     battery_data=$(acpi -b 2>/dev/null | head -1)
 

--- a/sections/dotnet.zsh
+++ b/sections/dotnet.zsh
@@ -24,8 +24,7 @@ SPACESHIP_DOTNET_COLOR="${SPACESHIP_DOTNET_COLOR="128"}"
 spaceship_dotnet() {
   [[ $SPACESHIP_DOTNET_SHOW == false ]] && return
 
-  # Show DOTNET status only for folders containing project.json, global.json, .csproj, .xproj or .sln files
-  [[ -f project.json || -f global.json || -f paket.dependencies || -n *.csproj(#qN^/) || -n *.fsproj(#qN^/) || -n *.xproj(#qN^/) || -n *.sln(#qN^/) ]] || return
+  [[ -f project.json || -f global.json || -f paket.dependencies || -n *.(cs|fs|x)proj(#qN^/) || -n *.sln(#qN^/) ]] || return
 
   spaceship::exists dotnet || return
 

--- a/sections/dotnet.zsh
+++ b/sections/dotnet.zsh
@@ -25,7 +25,7 @@ spaceship_dotnet() {
   [[ $SPACESHIP_DOTNET_SHOW == false ]] && return
 
   # Show DOTNET status only for folders containing project.json, global.json, .csproj, .xproj or .sln files
-  [[ -f project.json || -f global.json || -n *.csproj(#qN^/) || -n *.xproj(#qN^/) || -n *.sln(#qN^/) ]] || return
+  [[ -f project.json || -f global.json || -f paket.dependencies || -n *.csproj(#qN^/) || -n *.fsproj(#qN^/) || -n *.xproj(#qN^/) || -n *.sln(#qN^/) ]] || return
 
   spaceship::exists dotnet || return
 

--- a/sections/golang.zsh
+++ b/sections/golang.zsh
@@ -23,7 +23,7 @@ spaceship_golang() {
   [[ $SPACESHIP_GOLANG_SHOW == false ]] && return
 
   # If there are Go-specific files in current directory, or current directory is under the GOPATH
-  [[ -f go.mod || -d Godeps || -f glide.yaml || -n *.go(#qN^/) || -f Gopkg.yml || -f Gopkg.lock \
+  [[ -f go.mod || -d Godeps || -f glide.yaml || -n *.go(#qN^/) || -f Gopkg.toml || -f Gopkg.lock \
   || ( $GOPATH && "$PWD/" =~ "$GOPATH/" ) ]] || return
 
   spaceship::exists go || return

--- a/sections/swift.zsh
+++ b/sections/swift.zsh
@@ -31,7 +31,7 @@ spaceship_swift() {
     if swiftenv version | grep ".swift-version" > /dev/null; then
       swift_version=$(swiftenv version | sed 's/ .*//')
     elif [ -f Package.swift ]; then
-      swift_version=$(swift package tools-version | sed 's/ .*//')
+      swift_version=$(swiftenv version | sed 's/ .*//')
     fi
   fi
 

--- a/sections/swift.zsh
+++ b/sections/swift.zsh
@@ -30,6 +30,8 @@ spaceship_swift() {
   elif [[ $SPACESHIP_SWIFT_SHOW_LOCAL == true ]] ; then
     if swiftenv version | grep ".swift-version" > /dev/null; then
       swift_version=$(swiftenv version | sed 's/ .*//')
+    elif [ -f Package.swift ]; then
+      swift_version=$(swift package tools-version | sed 's/ .*//')
     fi
   fi
 

--- a/sections/swift.zsh
+++ b/sections/swift.zsh
@@ -21,18 +21,33 @@ SPACESHIP_SWIFT_COLOR="${SPACESHIP_SWIFT_COLOR="yellow"}"
 
 # Show current version of Swift
 spaceship_swift() {
-  spaceship::exists swiftenv || return
 
-  local 'swift_version'
+  if spaceship::exists swiftenv; then
+    # swiftenv installed
 
-  if [[ $SPACESHIP_SWIFT_SHOW_GLOBAL == true ]] ; then
-    swift_version=$(swiftenv version | sed 's/ .*//')
-  elif [[ $SPACESHIP_SWIFT_SHOW_LOCAL == true ]] ; then
-    if swiftenv version | grep ".swift-version" > /dev/null; then
+    local 'swift_version'
+
+    if [[ $SPACESHIP_SWIFT_SHOW_GLOBAL == true ]] ; then
       swift_version=$(swiftenv version | sed 's/ .*//')
-    elif [ -f Package.swift ]; then
-      swift_version=$(swiftenv version | sed 's/ .*//')
+    elif [[ $SPACESHIP_SWIFT_SHOW_LOCAL == true ]] ; then
+      if swiftenv version | grep ".swift-version" > /dev/null; then
+        swift_version=$(swiftenv version | sed 's/ .*//')
+      elif [ -f Package.swift ]; then
+        swift_version=$(swiftenv version | sed 's/ .*//')
+      fi
     fi
+
+  elif spaceship::exists swift-package; then
+    # Swift Package Manager available, swiftenv not installed
+
+    local 'swift_version'
+
+    if [ -f Package.swift ]; then
+      swift_version=$(swift package tools-version | sed 's/ .*//')
+    fi
+
+  else # Neither swiftenv nor SPM installed
+    return
   fi
 
   [ -n "${swift_version}" ] || return

--- a/sections/swift.zsh
+++ b/sections/swift.zsh
@@ -22,30 +22,23 @@ SPACESHIP_SWIFT_COLOR="${SPACESHIP_SWIFT_COLOR="yellow"}"
 # Show current version of Swift
 spaceship_swift() {
 
+  local 'swift_version'
+
   if spaceship::exists swiftenv; then
-    # swiftenv installed
 
-    local 'swift_version'
-
-    if [[ $SPACESHIP_SWIFT_SHOW_GLOBAL == true ]] ; then
-      swift_version=$(swiftenv version | sed 's/ .*//')
-    elif [[ $SPACESHIP_SWIFT_SHOW_LOCAL == true ]] ; then
-      if swiftenv version | grep ".swift-version" > /dev/null; then
-        swift_version=$(swiftenv version | sed 's/ .*//')
-      elif [ -f Package.swift ]; then
-        swift_version=$(swiftenv version | sed 's/ .*//')
-      fi
+    # Reads swift version from swiftenv
+    if [[ $SPACESHIP_SWIFT_SHOW_GLOBAL == true ]] \
+    || ([[ $SPACESHIP_SWIFT_SHOW_LOCAL == true ]] && [ -f Package.swift ]) \
+    || ([[ $SPACESHIP_SWIFT_SHOW_LOCAL == true ]] && (swiftenv version | grep ".swift-version" > /dev/null))
+    then
+      swift_version=$( swiftenv version | sed 's/ .*//' )
     fi
 
-  elif spaceship::exists swift-package; then
-    # Swift Package Manager available, swiftenv not installed
+  elif spaceship::exists swift; then
 
-    local 'swift_version'
-
-    if [[ $SPACESHIP_SWIFT_SHOW_LOCAL == true ]] ; then
-      if [ -f Package.swift ]; then
-        swift_version=$(swift package tools-version | sed 's/ .*//')
-      fi
+    # Reads swift version from SPM tools-version
+    if [[ $SPACESHIP_SWIFT_SHOW_LOCAL == true && -f Package.swift ]] ; then
+      swift_version=$( swift package tools-version | sed 's/ .*//'  )
     fi
 
   else # Neither swiftenv nor SPM installed

--- a/sections/swift.zsh
+++ b/sections/swift.zsh
@@ -42,8 +42,10 @@ spaceship_swift() {
 
     local 'swift_version'
 
-    if [ -f Package.swift ]; then
-      swift_version=$(swift package tools-version | sed 's/ .*//')
+    if [[ $SPACESHIP_SWIFT_SHOW_LOCAL == true ]] ; then
+      if [ -f Package.swift ]; then
+        swift_version=$(swift package tools-version | sed 's/ .*//')
+      fi
     fi
 
   else # Neither swiftenv nor SPM installed

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -7,7 +7,7 @@
 
 # Current version of Spaceship
 # Useful for issue reporting
-export SPACESHIP_VERSION='3.11.1'
+export SPACESHIP_VERSION='3.11.2'
 
 # Common-used variable for new line separator
 NEWLINE='

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -7,7 +7,7 @@
 
 # Current version of Spaceship
 # Useful for issue reporting
-export SPACESHIP_VERSION='3.11.0'
+export SPACESHIP_VERSION='3.11.1'
 
 # Common-used variable for new line separator
 NEWLINE='

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -7,7 +7,7 @@
 
 # Current version of Spaceship
 # Useful for issue reporting
-export SPACESHIP_VERSION='3.10.0'
+export SPACESHIP_VERSION='3.11.0'
 
 # Common-used variable for new line separator
 NEWLINE='

--- a/tests/utils.test.zsh
+++ b/tests/utils.test.zsh
@@ -56,6 +56,7 @@ test_is_hg() {
 
   local REPO="$SHUNIT_TMPDIR/utils/is_hg"
   mkdir -p $REPO/foo
+  mkdir -p "$REPO/../foo with space"
   cd $REPO
 
   if spaceship::exists hg; then
@@ -65,6 +66,8 @@ test_is_hg() {
   assertTrue "should be a hg repo" '$(spaceship::is_hg)'
   cd foo
   assertTrue "foo should be in hg repo" '$(spaceship::is_hg)'
+  cd "../../foo with space"
+  assertFalse "'foo with space' directory should not be in hg repo" '$(spaceship::is_hg)'
   cd ../..
   assertFalse "should not be a hg repo" '$(spaceship::is_hg)'
 


### PR DESCRIPTION
#### Description

If a Package.swift file exists in current working dir and unless swiftenv defines the global or local swift version the SPM tools-version is used as swift prompt version.

#### Screenshot

![image](https://user-images.githubusercontent.com/10276208/50003623-46235f00-ffca-11e8-87a4-b064efe21dd2.png)

Edit: Direct embed screenshot