### PR TITLE
 fix: Fix bug that jq returns null when version does't exist

### DIFF
--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -38,7 +38,7 @@ spaceship_package() {
     package_version=$(node -p "require('./package.json').version" 2> /dev/null)
   fi
 
-  [[ -z $package_version || "$package_version" == "undefined" ]] && return
+  [[ -z $package_version || "$package_version" == "null" || "$package_version" == "undefined" ]] && return
 
   spaceship::section \
     "$SPACESHIP_PACKAGE_COLOR" \


### PR DESCRIPTION
`jq` returns null when version does't exist



```bash
sourcegraph on  master is 📦 vnull via ⬢ v8.10.0 via 🐹 v1.11.4 at ☸️  docker-for-desktop took 45s
```
