### PR TITLE
Truncate conda env names with custom prefix

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -429,7 +429,7 @@ Show activated conda virtual environment. Disable native conda prompt by `conda 
 | `SPACESHIP_CONDA_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the conda virtualenv section |
 | `SPACESHIP_CONDA_SYMBOL` | `🅒·` | Character to be shown before conda virtualenv section |
 | `SPACESHIP_CONDA_COLOR` | `blue` | Color of conda virtualenv environment section |
-| `SPACESHIP_CONDA_VERBOSE` | `true` | Toggle to truncate conda environment under custom prefix |
+| `SPACESHIP_CONDA_VERBOSE` | `true` | Toggle to truncate environment names under custom prefix |
 
 ### Pyenv (`pyenv`)
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -429,6 +429,7 @@ Show activated conda virtual environment. Disable native conda prompt by `conda 
 | `SPACESHIP_CONDA_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the conda virtualenv section |
 | `SPACESHIP_CONDA_SYMBOL` | `🅒·` | Character to be shown before conda virtualenv section |
 | `SPACESHIP_CONDA_COLOR` | `blue` | Color of conda virtualenv environment section |
+| `SPACESHIP_CONDA_VERBOSE` | `true` | Toggle to truncate conda environment under custom prefix |
 
 ### Pyenv (`pyenv`)
 

--- a/sections/conda.zsh
+++ b/sections/conda.zsh
@@ -13,6 +13,7 @@ SPACESHIP_CONDA_PREFIX="${SPACESHIP_CONDA_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREF
 SPACESHIP_CONDA_SUFFIX="${SPACESHIP_CONDA_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_CONDA_SYMBOL="${SPACESHIP_CONDA_SYMBOL="🅒 "}"
 SPACESHIP_CONDA_COLOR="${SPACESHIP_CONDA_COLOR="blue"}"
+SPACESHIP_CONDA_VERBOSE="${SPACESHIP_CONDA_VERBOSE=true}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -25,9 +26,16 @@ spaceship_conda() {
   # Check if running via conda virtualenv
   spaceship::exists conda && [ -n "$CONDA_DEFAULT_ENV" ] || return
 
+  local conda_env=${CONDA_DEFAULT_ENV}
+
+  if [[ $SPACESHIP_CONDA_VERBOSE == false ]]; then
+    conda_env=${CONDA_DEFAULT_ENV:t}
+  fi
+
+
   spaceship::section \
     "$SPACESHIP_CONDA_COLOR" \
     "$SPACESHIP_CONDA_PREFIX" \
-    "${SPACESHIP_CONDA_SYMBOL}${CONDA_DEFAULT_ENV:t}" \
+    "${SPACESHIP_CONDA_SYMBOL}${conda_env}" \
     "$SPACESHIP_CONDA_SUFFIX"
 }

--- a/sections/conda.zsh
+++ b/sections/conda.zsh
@@ -28,6 +28,6 @@ spaceship_conda() {
   spaceship::section \
     "$SPACESHIP_CONDA_COLOR" \
     "$SPACESHIP_CONDA_PREFIX" \
-    "${SPACESHIP_CONDA_SYMBOL}${CONDA_DEFAULT_ENV}" \
+    "${SPACESHIP_CONDA_SYMBOL}${CONDA_DEFAULT_ENV:t}" \
     "$SPACESHIP_CONDA_SUFFIX"
 }


### PR DESCRIPTION
Conda environments created with custom prefixes returns complete path as
`CONDA_DEFAULT_ENV` instead of just the environment name. Now truncating
it to show the last component (`basename`) in path returned, also works
with simple environment names.

Fix #589