### PR TITLE
Fix battery_status with acpi

### DIFF
--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -56,7 +56,7 @@ spaceship_battery() {
 	# If battery is 0% charge, battery likely doesn't exist.
     [[ $battery_percent == "0%," ]] && return
 
-    battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
+    battery_status="$( echo $battery_data | awk '{print tolower($3)}' | tr -d ',')"
   elif spaceship::exists upower; then
     local battery=$(command upower -e | grep battery | head -1)
 


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description
`battery_data=$(acpi -b 2>/dev/null | head -1)`
`battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"`

`echo $battery_status`
`> charging,`

This leaves `$battery_status` to be `charging,` whereas it needs to be `charging`. Therefore, we need to strip the output




<!-- Describe your pull-request, what was changed and why… -->

#### Screenshot

<!-- Please, attach a screenshot, if possible.

[screenshot](https://pasteboard.co/HTylT58.png)
