### PR TITLE
fix: go development version

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -325,7 +325,7 @@ If you are using a development version of `Go`, the version uses git commit hash
 
 For example:
 
-* `v+5efe9a8f11` for development version
+* `devel:5efe9a8f11` for development version
 * `v1.11.4` for release version
 
 | Variable | Default | Meaning |

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -321,6 +321,13 @@ Shows current version of Swift. Local version has more priority than global.
 
 Go section is shown only in directories that contain `go.mod`, `Godeps`, `glide.yaml`, any other file with `.go` extension, or when current directory is in the Go workspace defined in `$GOPATH`.
 
+If you are using a development version of `Go`, the version use git commit hash instead.
+
+For example:
+
+* `v+5efe9a8f11` for development version
+* `v1.11.4` for release version
+
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_GOLANG_SHOW` | `true` | Shown current Go version or not |

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -321,7 +321,7 @@ Shows current version of Swift. Local version has more priority than global.
 
 Go section is shown only in directories that contain `go.mod`, `Godeps`, `glide.yaml`, any other file with `.go` extension, or when current directory is in the Go workspace defined in `$GOPATH`.
 
-If you are using a development version of `Go`, the version use git commit hash instead.
+If you are using a development version of `Go`, the version uses git commit hash instead.
 
 For example:
 

--- a/sections/golang.zsh
+++ b/sections/golang.zsh
@@ -31,11 +31,11 @@ spaceship_golang() {
   # Go version is either the commit hash and date like "devel +5efe9a8f11 Web Jan 9 07:21:16 2019 +0000"
   # at the time of the build or a release tag like "go1.11.4".
   # https://github.com/denysdovhan/spaceship-prompt/issues/610
-  local go_version=$(go version | awk '{ if ($3 ~ /^devel/) {print $4} else {print substr($3, 3)} }')
+  local go_version=$(go version | awk '{ if ($3 ~ /^devel/) {print $3 ":" substr($4, 2)} else {print "v" substr($3, 3)} }')
 
   spaceship::section \
     "$SPACESHIP_GOLANG_COLOR" \
     "$SPACESHIP_GOLANG_PREFIX" \
-    "${SPACESHIP_GOLANG_SYMBOL}v${go_version}" \
+    "${SPACESHIP_GOLANG_SYMBOL}${go_version}" \
     "$SPACESHIP_GOLANG_SUFFIX"
 }

--- a/sections/golang.zsh
+++ b/sections/golang.zsh
@@ -28,6 +28,9 @@ spaceship_golang() {
 
   spaceship::exists go || return
 
+  # Go version is either the commit hash and date like "devel +5efe9a8f11 Web Jan 9 07:21:16 2019 +0000"
+  # at the time of the build or a release tag like "go1.11.4".
+  # https://github.com/denysdovhan/spaceship-prompt/issues/610
   local go_version=$(go version | awk '{ if ($3 ~ /^devel/) {print $4} else {print substr($3, 3)} }')
 
   spaceship::section \

--- a/sections/golang.zsh
+++ b/sections/golang.zsh
@@ -28,7 +28,7 @@ spaceship_golang() {
 
   spaceship::exists go || return
 
-  local go_version=$(go version | awk '{print substr($3, 3)}' )
+  local go_version=$(go version | awk '{ if ($3 ~ /^devel/) {print $4} else {print substr($3, 3)} }')
 
   spaceship::section \
     "$SPACESHIP_GOLANG_COLOR" \


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

```
// Version returns the Go tree's version string.
// It is either the commit hash and date at the time of the build or,
// when possible, a release tag like "go1.3".
```

Read more [Go version detail](https://github.com/golang/go/blob/5ec5c5741ec7d0e051667f13094f532833d41578/src/cmd/dist/build.go#L328)

I try to use commit hash for devel version. Any suggestions ?

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
![image](https://user-images.githubusercontent.com/1078011/51070493-33f61880-167d-11e9-9c7c-329d327beee8.png)


Fix #610 
