### PR TITLE
Package: Support cargo package manager (Rust)

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -225,9 +225,17 @@ Mercurial status indicators is shown only when you have dirty repository.
 
 ### Package version (`package`)
 
-> Works only for [npm](https://www.npmjs.com/) at the moment. Please, help us improve this section!
+> Works for [npm](https://www.npmjs.com/) and [cargo](https://crates.io/) at the moment. Please, help us improve this section!
 
-Package version is shown when repository is a package (e.g. contains a `package.json` file). Install [jq](https://stedolan.github.io/jq/) for **improved performace** of this section ([Why?](./Troubleshooting.md#why-is-my-prompt-slow))
+Package version is shown when repository is a package.
+
+* npm
+
+  `npm` package contains a `package.json` file. Install [jq](https://stedolan.github.io/jq/) for **improved performace** of this section ([Why?](./Troubleshooting.md#why-is-my-prompt-slow))
+
+* cargo
+
+  `cargo` package contains a `Cargo.toml` file.
 
 > **Note:** This is the version of the package you are working on, not the version of package manager itself.
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -229,13 +229,8 @@ Mercurial status indicators is shown only when you have dirty repository.
 
 Package version is shown when repository is a package.
 
-* npm
-
-  `npm` package contains a `package.json` file. We use `jq`, `python` to parse package version for improving performance and `node` as a fallback. Install [jq](https://stedolan.github.io/jq/) for **improved performance** of this section ([Why?](./Troubleshooting.md#why-is-my-prompt-slow))
-
-* cargo
-
-  `cargo` package contains a `Cargo.toml` file. Currently, we use `cargo pkgid`, it depends on `Cargo.lock`. So if package version isn't shown, you may need to run some command like `cargo build` which can generate `Cargo.lock` file.
+* **npm** — `npm` package contains a `package.json` file. We use `jq`, `python` to parse package version for improving performance and `node` as a fallback. Install [jq](https://stedolan.github.io/jq/) for **improved performance** of this section ([Why?](./Troubleshooting.md#why-is-my-prompt-slow))
+* **cargo** — `cargo` package contains a `Cargo.toml` file. Currently, we use `cargo pkgid`, it depends on `Cargo.lock`. So if package version isn't shown, you may need to run some command like `cargo build` which can generate `Cargo.lock` file.
 
 > **Note:** This is the version of the package you are working on, not the version of package manager itself.
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -231,7 +231,7 @@ Package version is shown when repository is a package.
 
 * npm
 
-  `npm` package contains a `package.json` file. Install [jq](https://stedolan.github.io/jq/) for **improved performace** of this section ([Why?](./Troubleshooting.md#why-is-my-prompt-slow))
+  `npm` package contains a `package.json` file. We use `jq`, `python` to parse package version for improving performance and `node` as a fallback. Install [jq](https://stedolan.github.io/jq/) for **improved performance** of this section ([Why?](./Troubleshooting.md#why-is-my-prompt-slow))
 
 * cargo
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -235,7 +235,7 @@ Package version is shown when repository is a package.
 
 * cargo
 
-  `cargo` package contains a `Cargo.toml` file.
+  `cargo` package contains a `Cargo.toml` file. Currently, we use `cargo pkgid`, it depends on `Cargo.lock`. So if package version isn't shown, you may need to run some command like `cargo build` which can generate `Cargo.lock` file.
 
 > **Note:** This is the version of the package you are working on, not the version of package manager itself.
 

--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -4,6 +4,7 @@
 # Current package version.
 # These package managers supported:
 #   * NPM
+#   * Cargo
 
 # ------------------------------------------------------------------------------
 # Configuration
@@ -23,20 +24,22 @@ spaceship_package() {
   [[ $SPACESHIP_PACKAGE_SHOW == false ]] && return
 
   # Show package version only when repository is a package
-  # @todo: add more package managers
-  [[ -f package.json ]] || return
-
-  spaceship::exists npm || return
-
   local 'package_version'
 
-  if spaceship::exists jq; then
-    package_version=$(jq -r '.version' package.json 2>/dev/null)
-  elif spaceship::exists python; then
-    package_version=$(python -c "import json; print(json.load(open('package.json'))['version'])" 2>/dev/null)
-  elif spaceship::exists node; then
-    package_version=$(node -p "require('./package.json').version" 2> /dev/null)
-  fi
+  [[ -f package.json ]] && spaceship::exists npm && {
+    if spaceship::exists jq; then
+      package_version=$(jq -r '.version' package.json 2>/dev/null)
+    elif spaceship::exists python; then
+      package_version=$(python -c "import json; print(json.load(open('package.json'))['version'])" 2>/dev/null)
+    elif spaceship::exists node; then
+      package_version=$(node -p "require('./package.json').version" 2> /dev/null)
+    fi
+  }
+
+  [[ -f Cargo.toml ]] && spaceship::exists cargo && {
+    local pkgid=$(cargo pkgid)
+    package_version=${pkgid##*\#}
+  }
 
   [[ -z $package_version || "$package_version" == "null" || "$package_version" == "undefined" ]] && return
 

--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -37,8 +37,11 @@ spaceship_package() {
   }
 
   [[ -f Cargo.toml ]] && spaceship::exists cargo && {
-    local pkgid=$(cargo pkgid 2> /dev/null)
-    package_version=${pkgid##*\#}
+    # Handle missing field `version` in Cargo.toml.
+    # `cargo pkgid` need Cargo.lock exists too. If it does't, do not show package version
+    # https://github.com/denysdovhan/spaceship-prompt/pull/617
+    local pkgid=$(cargo pkgid 2>&1)
+    echo $pkgid | grep -q "error:" || package_version=${pkgid##*\#}
   }
 
   [[ -z $package_version || "$package_version" == "null" || "$package_version" == "undefined" ]] && return

--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -26,7 +26,7 @@ spaceship_package() {
   # Show package version only when repository is a package
   local 'package_version'
 
-  [[ -f package.json ]] && spaceship::exists npm && {
+  if [[ -f package.json ]] && spaceship::exists npm; then
     if spaceship::exists jq; then
       package_version=$(jq -r '.version' package.json 2>/dev/null)
     elif spaceship::exists python; then
@@ -34,15 +34,15 @@ spaceship_package() {
     elif spaceship::exists node; then
       package_version=$(node -p "require('./package.json').version" 2> /dev/null)
     fi
-  }
+  fi
 
-  [[ -f Cargo.toml ]] && spaceship::exists cargo && {
+  if [[ -f Cargo.toml ]] && spaceship::exists cargo; then
     # Handle missing field `version` in Cargo.toml.
     # `cargo pkgid` need Cargo.lock exists too. If it does't, do not show package version
     # https://github.com/denysdovhan/spaceship-prompt/pull/617
     local pkgid=$(cargo pkgid 2>&1)
     echo $pkgid | grep -q "error:" || package_version=${pkgid##*\#}
-  }
+  fi
 
   [[ -z $package_version || "$package_version" == "null" || "$package_version" == "undefined" ]] && return
 

--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -37,7 +37,7 @@ spaceship_package() {
   }
 
   [[ -f Cargo.toml ]] && spaceship::exists cargo && {
-    local pkgid=$(cargo pkgid)
+    local pkgid=$(cargo pkgid 2> /dev/null)
     package_version=${pkgid##*\#}
   }
 


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

Make package section support cargo package manager.

If there is a missing field `version` in Cargo.toml, the following error occur:
```
error: failed to parse manifest at `/path/to/Cargo.toml`

Caused by:
missing field `version` for key `package`
```
Currently, we use `cargo pkgid`.
```
$ cargo pkgid
> file:///path/to/tokio-rs/tokio#0.1.14
```
But it depends on `cargo.lock`. So we need handle the following error:
```
error: a Cargo.lock must exist for this command
```

__If you work on a rust package, you almost have a cargo.lock in package root directory except you just only clone a package without any work.__

<!-- Describe your pull-request, what was changed and why… -->

#### Screenshot
![image](https://user-images.githubusercontent.com/1078011/51362178-81ef9e00-1b0d-11e9-8139-76af0162dfd3.png)

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
