### PR TITLE
Add detection for F# project files

### DIFF
--- a/sections/dotnet.zsh
+++ b/sections/dotnet.zsh
@@ -24,8 +24,7 @@ SPACESHIP_DOTNET_COLOR="${SPACESHIP_DOTNET_COLOR="128"}"
 spaceship_dotnet() {
   [[ $SPACESHIP_DOTNET_SHOW == false ]] && return
 
-  # Show DOTNET status only for folders containing project.json, global.json, .csproj, .xproj or .sln files
-  [[ -f project.json || -f global.json || -f paket.dependencies || -n *.csproj(#qN^/) || -n *.fsproj(#qN^/) || -n *.xproj(#qN^/) || -n *.sln(#qN^/) ]] || return
+  [[ -f project.json || -f global.json || -f paket.dependencies || -n *.(cs|fs|x)proj(#qN^/) || -n *.sln(#qN^/) ]] || return
 
   spaceship::exists dotnet || return
 

--- a/sections/dotnet.zsh
+++ b/sections/dotnet.zsh
@@ -25,7 +25,7 @@ spaceship_dotnet() {
   [[ $SPACESHIP_DOTNET_SHOW == false ]] && return
 
   # Show DOTNET status only for folders containing project.json, global.json, .csproj, .xproj or .sln files
-  [[ -f project.json || -f global.json || -n *.csproj(#qN^/) || -n *.xproj(#qN^/) || -n *.sln(#qN^/) ]] || return
+  [[ -f project.json || -f global.json || -f paket.dependencies || -n *.csproj(#qN^/) || -n *.fsproj(#qN^/) || -n *.xproj(#qN^/) || -n *.sln(#qN^/) ]] || return
 
   spaceship::exists dotnet || return
 


### PR DESCRIPTION
This is a downstream improvement that was proposed by @yjpark in matchai/spacefish#145

<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description
Add detection of F# project files to the dotnet section by detecting the following files:
- paket.dependencies
- *.fsproj
