### PR TITLE
Fix a bug with the battery status icon on MacOS

### DIFF
--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -44,7 +44,7 @@ spaceship_battery() {
     [[ -z "$battery_data" ]] && return
 
     battery_percent="$( echo $battery_data | grep -oE '[0-9]{1,3}%' )"
-    battery_status="$( echo $battery_data | awk -F '; *' 'NR==2 { print $2 }' )"
+    battery_status="$( echo $battery_data | cut -d ';' -f 2 | xargs )"
   elif spaceship::exists acpi; then
     battery_data=$(acpi -b 2>/dev/null | head -1)
 


### PR DESCRIPTION
#### Description

The prompt has a bug in MacOS that for all types of battery status it was showing just one symbol `SPACESHIP_BATTERY_SYMBOL_FULL`. I fixed it with `cut` command and now it works exactly as it is written in the docs.

#### Screenshot

This is what you got before for everything (charging/discharging/full etc.):

<img width="762" alt="screen shot 2019-02-11 at 4 03 00 pm" src="https://user-images.githubusercontent.com/22010816/52562011-89594d00-2e16-11e9-9239-64daeaa3c960.png">

Now:

Discharging:
<img width="762" alt="screen shot 2019-02-11 at 4 03 31 pm" src="https://user-images.githubusercontent.com/22010816/52562087-c32a5380-2e16-11e9-9b1d-70b5c68554d5.png">

Full charge:
<img width="762" alt="screen shot 2019-02-11 at 4 09 03 pm" src="https://user-images.githubusercontent.com/22010816/52562251-624f4b00-2e17-11e9-92fc-bdec1d3b59f7.png">

Charging:
<img width="762" alt="screen shot 2019-02-11 at 4 04 43 pm" src="https://user-images.githubusercontent.com/22010816/52562088-c3c2ea00-2e16-11e9-9eeb-2acda8f87e26.png">