### PR TITLE
Add Crystal section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Spaceship is a minimalistic, powerful and extremely customizable [Zsh][zsh-url] 
 - Indicator for jobs in the background (`✦`).
 - Current Node.js version, through nvm/nodenv/n (`⬢`).
 - Current Ruby version, through rvm/rbenv/chruby/asdf (`💎`).
+- Current Crystal version (`💎`).
 - Current Elm version (`🌳`)
 - Current Elixir version, through kiex/exenv/elixir (`💧`).
 - Current Swift version, through swiftenv (`🐦`).

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -25,6 +25,7 @@ SPACESHIP_PROMPT_ORDER=(
   package       # Package version
   node          # Node.js section
   ruby          # Ruby section
+  crystal       # Crystal section
   elixir        # Elixir section
   xcode         # Xcode section
   swift         # Swift section
@@ -268,6 +269,19 @@ Ruby section is shown only in directories that contain `Gemfile`, or `Rakefile`,
 | `SPACESHIP_RUBY_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Ruby section |
 | `SPACESHIP_RUBY_SYMBOL` | `💎·` | Character to be shown before Ruby version |
 | `SPACESHIP_RUBY_COLOR` | `red` | Color of Ruby section |
+
+### Crystal (`crystal`)
+
+Crystal section is shown only in directories that contain `shatds.yml` or any ther file with `.cr` extension.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_CRYSTAL_SHOW` | `true` | Show Crystal section |
+| `SPACESHIP_CRYSTAL_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Crystal section |
+| `SPACESHIP_CRYSTAL_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Crystal section |
+| `SPACESHIP_CRYSTAL_SYMBOL` | `💎·` | Character to be shown before Crystal version |
+| `SPACESHIP_CRYSTAL_COLOR` | `black` | Color of Crystal section |
+
 
 ### Elm (`elm`)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
   * [Package version (package)](/docs/Options.md#package-version-package)
   * [Node (node)](/docs/Options.md#nodejs-node)
   * [Ruby (ruby)](/docs/Options.md#ruby-ruby)
+  * [Crystal (crystal)](/docs/Options.md#crystal-crystal)
   * [Elm (elm)](/docs/Options.md#elm-elm)
   * [Elixir (elixir)](/docs/Options.md#elixir-elixir)
   * [Xcode (xcode)](/docs/Options.md#xcode-xcode)

--- a/sections/crystal.zsh
+++ b/sections/crystal.zsh
@@ -1,0 +1,43 @@
+#
+# Crystal
+#
+# A compiled object-oriented language with static type-checking
+# Link: https://crystal-lang.org
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_CRYSTAL_SHOW="${SPACESHIP_CRYSTAL_SHOW=true}"
+SPACESHIP_CRYSTAL_PREFIX="${SPACESHIP_CRYSTAL_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_CRYSTAL_SUFFIX="${SPACESHIP_CRYSTAL_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_CRYSTAL_SYMBOL="${SPACESHIP_CRYSTAL_SYMBOL="💎 "}"
+SPACESHIP_CRYSTAL_COLOR="${SPACESHIP_CRYSTAL_COLOR="black"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show current version of Crystal
+spaceship_crystal() {
+  [[ $SPACESHIP_CRYSTAL_SHOW == false ]] && return
+
+  # Show Crystal version only for Crystal-specific folders
+  [[ -f shard.yml || -n *.cr(#qN^/) ]] || return
+
+  local 'crystal_version'
+
+  if spaceship::exists crystal; then
+    crystal_version=$(crystal -v | awk '/Crystal*/ {print $2}')
+  else
+    return
+  fi
+
+  [[ -z $crystal_version ]] && return
+
+  spaceship::section \
+    "$SPACESHIP_CRYSTAL_COLOR" \
+    "$SPACESHIP_CRYSTAL_PREFIX" \
+    "${SPACESHIP_CRYSTAL_SYMBOL}${crystal_version}" \
+    "$SPACESHIP_CRYSTAL_SUFFIX"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -49,6 +49,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     package       # Package version
     node          # Node.js section
     ruby          # Ruby section
+    crystal       # Crystal section
     elm           # Elm section
     elixir        # Elixir section
     xcode         # Xcode section


### PR DESCRIPTION
#### Description

This PR adds a section showing Crystal (http://crystal-lang.org/) version.

It uses the same icon as Ruby as I couldn't find anything more appropriate and they're unlikely to be used together.

#### Screenshot

<img width="416" alt="Screenshot 2019-03-28 at 19 10 32" src="https://user-images.githubusercontent.com/11964039/55174239-1d486380-518e-11e9-82fe-37f96f63ef22.png">
