### PR TITLE
Remove trailing symbols from battery_status

### DIFF
--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -72,6 +72,7 @@ spaceship_battery() {
 
   # Remove trailing % and symbols for comparison
   battery_percent="$(echo $battery_percent | tr -d '%[,;]')"
+  battery_status="$(echo $battery_status | tr -d '[,;]')"
 
   # Change color based on battery percentage
   if [[ $battery_percent == 100 || $battery_status =~ "(charged|full)" ]]; then


### PR DESCRIPTION
acpi -b gives something like `Battery 0: Charging, 30%, 01:35:26 until charged`.
When passing through awk the battery_status becomes 'charging,' and the
trailing comma messes with the comparison.

This commit remove trailing comma and semi-colon so that the charging
indicator works correctly under Linux.