### PR TITLE
Fix installation instructions for antigen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Set `ZSH_THEME="spaceship"` in your `.zshrc`.
 Add the following snippet in your `~/.zshrc`:
 
 ```
-antigen theme denysdovhan/spaceship-prompt
+antigen bundle denysdovhan/spaceship-prompt
 ```
 
 ### [antibody]


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

`antigen theme denysdovhan/spaceship-prompt` fails for antigen. The way to make this prompt work is to use it as a plugin through `bundle`.

<!-- Describe your pull-request, what was changed and why… -->

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
