### PR TITLE
Remove unnecessary pipes from the codes

### DIFF
--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -43,20 +43,20 @@ spaceship_battery() {
     # Return if no internal battery
     [[ -z "$battery_data" ]] && return
 
-    battery_percent="$( echo $battery_data | grep -oE '[0-9]{1,3}%' )"
-    battery_status="$( echo $battery_data | awk -F '; *' 'NR==2 { print $2 }' )"
+    battery_percent="$( <<< $battery_data grep -oE '[0-9]{1,3}%' )"
+    battery_status="$( <<< $battery_data awk -F '; *' 'NR==2 { print $2 }' )"
   elif spaceship::exists acpi; then
     battery_data=$(acpi -b 2>/dev/null | head -1)
 
     # Return if no battery
     [[ -z $battery_data ]] && return
 
-    battery_percent="$( echo $battery_data | awk '{print $4}' )"
+    battery_percent="$( <<< $battery_data awk '{print $4}' )"
 
-	# If battery is 0% charge, battery likely doesn't exist.
+    # If battery is 0% charge, battery likely doesn't exist.
     [[ $battery_percent == "0%," ]] && return
 
-    battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
+    battery_status="$( <<< $battery_data awk '{print tolower($3)}' )"
   elif spaceship::exists upower; then
     local battery=$(command upower -e | grep battery | head -1)
 
@@ -64,14 +64,14 @@ spaceship_battery() {
     [[ -z $battery ]] && return
 
     battery_data=$(upower -i $battery)
-    battery_percent="$( echo "$battery_data" | grep percentage | awk '{print $2}' )"
-    battery_status="$( echo "$battery_data" | grep state | awk '{print $2}' )"
+    battery_percent="$( <<< "$battery_data" grep percentage | awk '{print $2}' )"
+    battery_status="$( <<< "$battery_data" grep state | awk '{print $2}' )"
   else
     return
   fi
 
   # Remove trailing % and symbols for comparison
-  battery_percent="$(echo $battery_percent | tr -d '%[,;]')"
+  battery_percent="$(<<< $battery_percent tr -d '%[,;]')"
 
   # Change color based on battery percentage
   if [[ $battery_percent == 100 || $battery_status =~ "(charged|full)" ]]; then

--- a/sections/git_status.zsh
+++ b/sections/git_status.zsh
@@ -40,33 +40,33 @@ spaceship_git_status() {
   INDEX=$(command git status --porcelain -b 2> /dev/null)
 
   # Check for untracked files
-  if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
+  if $(<<< "$INDEX" command grep -E '^\?\? ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_UNTRACKED$git_status"
   fi
 
   # Check for staged files
-  if $(echo "$INDEX" | command grep '^A[ MDAU] ' &> /dev/null); then
+  if $(<<< "$INDEX" command grep '^A[ MDAU] ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_ADDED$git_status"
-  elif $(echo "$INDEX" | command grep '^M[ MD] ' &> /dev/null); then
+  elif $(<<< "$INDEX" command grep '^M[ MD] ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_ADDED$git_status"
-  elif $(echo "$INDEX" | command grep '^UA' &> /dev/null); then
+  elif $(<<< "$INDEX" command grep '^UA' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_ADDED$git_status"
   fi
 
   # Check for modified files
-  if $(echo "$INDEX" | command grep '^[ MARC]M ' &> /dev/null); then
+  if $(<<< "$INDEX" command grep '^[ MARC]M ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_MODIFIED$git_status"
   fi
 
   # Check for renamed files
-  if $(echo "$INDEX" | command grep '^R[ MD] ' &> /dev/null); then
+  if $(<<< "$INDEX" command grep '^R[ MD] ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_RENAMED$git_status"
   fi
 
   # Check for deleted files
-  if $(echo "$INDEX" | command grep '^[MARCDU ]D ' &> /dev/null); then
+  if $(<<< "$INDEX" command grep '^[MARCDU ]D ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_DELETED$git_status"
-  elif $(echo "$INDEX" | command grep '^D[ UM] ' &> /dev/null); then
+  elif $(<<< "$INDEX" command grep '^D[ UM] ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_DELETED$git_status"
   fi
 
@@ -76,25 +76,25 @@ spaceship_git_status() {
   fi
 
   # Check for unmerged files
-  if $(echo "$INDEX" | command grep '^U[UDA] ' &> /dev/null); then
+  if $(<<< "$INDEX" command grep '^U[UDA] ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
-  elif $(echo "$INDEX" | command grep '^AA ' &> /dev/null); then
+  elif $(<<< "$INDEX" command grep '^AA ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
-  elif $(echo "$INDEX" | command grep '^DD ' &> /dev/null); then
+  elif $(<<< "$INDEX" command grep '^DD ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
-  elif $(echo "$INDEX" | command grep '^[DA]U ' &> /dev/null); then
+  elif $(<<< "$INDEX" command grep '^[DA]U ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
   fi
 
   # Check whether branch is ahead
   local is_ahead=false
-  if $(echo "$INDEX" | command grep '^## [^ ]\+ .*ahead' &> /dev/null); then
+  if $(<<< "$INDEX" command grep '^## [^ ]\+ .*ahead' &> /dev/null); then
     is_ahead=true
   fi
 
   # Check whether branch is behind
   local is_behind=false
-  if $(echo "$INDEX" | command grep '^## [^ ]\+ .*behind' &> /dev/null); then
+  if $(<<< "$INDEX" command grep '^## [^ ]\+ .*behind' &> /dev/null); then
     is_behind=true
   fi
 

--- a/sections/hg_status.zsh
+++ b/sections/hg_status.zsh
@@ -30,16 +30,16 @@ spaceship_hg_status() {
 
   # Indicators are suffixed instead of prefixed to each other to
   # provide uniform view across git and mercurial indicators
-  if $(echo "$INDEX" | grep -E '^\? ' &> /dev/null); then
+  if $(<<< "$INDEX" grep -E '^\? ' &> /dev/null); then
     hg_status="$SPACESHIP_HG_STATUS_UNTRACKED$hg_status"
   fi
-  if $(echo "$INDEX" | grep -E '^A ' &> /dev/null); then
+  if $(<<< "$INDEX" grep -E '^A ' &> /dev/null); then
     hg_status="$SPACESHIP_HG_STATUS_ADDED$hg_status"
   fi
-  if $(echo "$INDEX" | grep -E '^M ' &> /dev/null); then
+  if $(<<< "$INDEX" grep -E '^M ' &> /dev/null); then
     hg_status="$SPACESHIP_HG_STATUS_MODIFIED$hg_status"
   fi
-  if $(echo "$INDEX" | grep -E '^(R|!)' &> /dev/null); then
+  if $(<<< "$INDEX" grep -E '^(R|!)' &> /dev/null); then
     hg_status="$SPACESHIP_HG_STATUS_DELETED$hg_status"
   fi
 

--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -41,7 +41,7 @@ spaceship_package() {
     # `cargo pkgid` need Cargo.lock exists too. If it does't, do not show package version
     # https://github.com/denysdovhan/spaceship-prompt/pull/617
     local pkgid=$(cargo pkgid 2>&1)
-    echo $pkgid | grep -q "error:" || package_version=${pkgid##*\#}
+    <<< $pkgid grep -q "error:" || package_version=${pkgid##*\#}
   fi
 
   [[ -z $package_version || "$package_version" == "null" || "$package_version" == "undefined" ]] && return

--- a/sections/rust.zsh
+++ b/sections/rust.zsh
@@ -31,7 +31,7 @@ spaceship_rust() {
   local rust_version=$(rustc --version | cut -d' ' -f2)
 
   if [[ $SPACESHIP_RUST_VERBOSE_VERSION == false ]]; then
-  	local rust_version=$(echo $rust_version | cut -d'-' -f1) # Cut off -suffixes from version. "v1.30.0-beta.11" or "v1.30.0-nightly"
+  	local rust_version=$(<<< $rust_version cut -d'-' -f1) # Cut off -suffixes from version. "v1.30.0-beta.11" or "v1.30.0-nightly"
   fi
 
   spaceship::section \


### PR DESCRIPTION
Pipes spawn subshells. Use herestring to remove unnecessary time cost on spawning the shells.