### PR TITLE
Go section detection: Gopkg.yml → Gopkg.toml

### DIFF
--- a/sections/golang.zsh
+++ b/sections/golang.zsh
@@ -23,7 +23,7 @@ spaceship_golang() {
   [[ $SPACESHIP_GOLANG_SHOW == false ]] && return
 
   # If there are Go-specific files in current directory, or current directory is under the GOPATH
-  [[ -f go.mod || -d Godeps || -f glide.yaml || -n *.go(#qN^/) || -f Gopkg.yml || -f Gopkg.lock \
+  [[ -f go.mod || -d Godeps || -f glide.yaml || -n *.go(#qN^/) || -f Gopkg.toml || -f Gopkg.lock \
   || ( $GOPATH && "$PWD/" =~ "$GOPATH/" ) ]] || return
 
   spaceship::exists go || return


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

<!-- Describe your pull-request, what was changed and why… -->
Howdy folks! 👋 

It looks like `Gopkg.yml` might've initially been a typo. Looking at the docs for the [dep package manager](https://golang.github.io/dep/docs/Gopkg.toml.html), the file it generates is `Gopkg.toml`, without any history of it previously being `Gopkg.yml`.

Even the PR that initially added this support mentioned `.toml` in the title and issue summary: https://github.com/denysdovhan/spaceship-prompt/pull/152 😅

