### PR TITLE
SPACESHIP_PROMPT_FIRST_PREFIX_SHOW must place before theme

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -1,6 +1,6 @@
 ## Options
 
-You have ability to customize or disable specific elements of Spaceship. All options must be overridden in your `.zshrc` file **after** the theme.
+You have ability to customize or disable specific elements of Spaceship. All options must be overridden in your `.zshrc` file **after** the theme, except `SPACESHIP_PROMPT_FIRST_PREFIX_SHOW`.
 
 Colors for sections can be [basic colors](https://wiki.archlinux.org/index.php/zsh#Colors) or [color codes](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg).
 


### PR DESCRIPTION
#### Description

SPACESHIP_PROMPT_FIRST_PREFIX_SHOW=true environment must be set before theme.

#### Screenshot

Place SPACESHIP_PROMPT_FIRST_PREFIX_SHOW=true after theme
<img width="533" alt="Screen Shot 2019-06-16 at 5 48 09 PM" src="https://user-images.githubusercontent.com/19373324/59563061-1e877f00-905f-11e9-9070-c2eecc487776.png">

Place SPACESHIP_PROMPT_FIRST_PREFIX_SHOW=true before theme
<img width="393" alt="Screen Shot 2019-06-16 at 5 48 32 PM" src="https://user-images.githubusercontent.com/19373324/59563062-20514280-905f-11e9-8348-947ac59fee60.png">
