### PR TITLE
Check environment variable first in pyenv

### DIFF
--- a/sections/pyenv.zsh
+++ b/sections/pyenv.zsh
@@ -27,7 +27,8 @@ spaceship_pyenv() {
 
   spaceship::exists pyenv || return # Do nothing if pyenv is not installed
 
-  local pyenv_status=${$(pyenv version-name 2>/dev/null)//:/ }
+  local pyenv_status="$PYENV_VERSION"
+  [[ -z $pyenv_status ]] && pyenv_status=${$(pyenv version-name 2>/dev/null)//:/ }
 
   spaceship::section \
     "$SPACESHIP_PYENV_COLOR" \


### PR DESCRIPTION
`PYENV_VERSION` is set after enabling virtual environment with `pyenv activate <venv-name>`. Although `pyenv version-name` is also capable checking this variable, it's much slower that checking the variable manually.

```zsh
❯ time (pyenv version-name)
2.7.16
0.05s user 0.04s system 96% cpu 0.097 total

❯ time (echo $PYENV_VERSION)
2.7.16
0.00s user 0.00s system 59% cpu 0.001 total
```

If the virtual environment is enabled by `pyenv local <venv-name>`, this var is not set. So we still need to fallback to `pyenv version-name`, which is more reliable.
