### PR TITLE
Fix zplug installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ zgen load denysdovhan/spaceship-prompt spaceship
 Use this command in your `.zshrc` to load Spaceship as prompt theme:
 
 ```
-zplug denysdovhan/spaceship-prompt, use:spaceship.zsh, from:github, as:theme
+zplug "denysdovhan/spaceship-prompt", use:spaceship.zsh, from:github, as:theme
 ```
 
 ### Linux package manager


### PR DESCRIPTION
#### Description

Surround plugin name with double quotes.

Although it works without double quotes, zplug README encourages to use double quotes.
https://github.com/zplug/zplug#example

#### Screenshot

None.