### PR TITLE
Docker: Add support for remote DOCKER_HOST

### DIFF
--- a/sections/docker.zsh
+++ b/sections/docker.zsh
@@ -46,8 +46,8 @@ spaceship_docker() {
     [[ "$compose_exists" == false ]] && return
   fi
 
-  # Show Docker status only for Docker-specific folders
-  [[ "$compose_exists" == true || -f Dockerfile || -f docker-compose.yml || -f /.dockerenv ]] || return
+  # Show Docker status only for Docker-specific folders or when connected to external host
+  [[ "$compose_exists" == true || -f Dockerfile || -f docker-compose.yml || -f /.dockerenv || -n $DOCKER_MACHINE_NAME || -n $DOCKER_HOST ]] || return
 
   # if docker daemon isn't running you'll get an error saying it can't connect
   local docker_version=$(docker version -f "{{.Server.Version}}" 2>/dev/null)
@@ -55,13 +55,19 @@ spaceship_docker() {
 
   [[ $SPACESHIP_DOCKER_VERBOSE == false ]] && docker_version=${docker_version%-*}
 
+  local docker_host=''
   if [[ -n $DOCKER_MACHINE_NAME ]]; then
-    docker_version+=" via ($DOCKER_MACHINE_NAME)"
+    docker_host=" via ($DOCKER_MACHINE_NAME)"
+  fi
+
+  if [[ -n $DOCKER_HOST ]]; then
+    # Remove protocol (tcp://) and port number from displayed Docker host
+    docker_host=" via ("$(basename $DOCKER_HOST | cut -d':' -f1)")"
   fi
 
   spaceship::section \
     "$SPACESHIP_DOCKER_COLOR" \
     "$SPACESHIP_DOCKER_PREFIX" \
-    "${SPACESHIP_DOCKER_SYMBOL}v${docker_version}" \
+    "${SPACESHIP_DOCKER_SYMBOL}v${docker_version}${docker_host}" \
     "$SPACESHIP_DOCKER_SUFFIX"
 }


### PR DESCRIPTION
### Description

Docker information should not only be shown when the user is in a directory with a local Dockerfile, but also if they are connected to remote Docker daemons. This can either be via `docker-machine` or by setting the environment variable `DOCKER_HOST` to a remote Docker daemon exposed over TCP (usually port 2375). 

#### Screenshot

![](https://user-images.githubusercontent.com/153481/60877241-bda62d80-a23d-11e9-8462-8a8da65c56c9.png)
