### PR TITLE
Gradle & Maven sections with optional JVM subsection

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -23,6 +23,7 @@ SPACESHIP_PROMPT_ORDER=(
   git           # Git section (git_branch + git_status)
   hg            # Mercurial section (hg_branch  + hg_status)
   package       # Package version
+  gradle        # Gradle section
   node          # Node.js section
   ruby          # Ruby section
   elixir        # Elixir section
@@ -550,6 +551,20 @@ SPACESHIP_KUBECONTEXT_COLOR_GROUPS=(
   yellow '^test-[0-9]+$'
 )
 ```
+
+### Gradle (`gradle`)
+
+Shows current gradle version.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_GRADLE_SHOW` | `true` | Current Gradle section |
+| `SPACESHIP_GRADLE_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Gradle section |
+| `SPACESHIP_GRADLE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Gradle section |
+| `SPACESHIP_GRADLE_SYMBOL` | `🐘️·` | Character to be shown before Gradle section |
+| `SPACESHIP_GRADLE_DEFAULT_VERSION` | ` ` | Gradle version to be treated as default |
+| `SPACESHIP_GRADLE_COLOR` | `green` | Color of Gradle section |
+
 
 ### Terraform workspace (`terraform`)
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -24,6 +24,7 @@ SPACESHIP_PROMPT_ORDER=(
   hg            # Mercurial section (hg_branch  + hg_status)
   package       # Package version
   gradle        # Gradle section
+  maven         # Maven section
   node          # Node.js section
   ruby          # Ruby section
   elixir        # Elixir section

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -561,10 +561,15 @@ Shows current gradle version.
 | `SPACESHIP_GRADLE_SHOW` | `true` | Current Gradle section |
 | `SPACESHIP_GRADLE_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Gradle section |
 | `SPACESHIP_GRADLE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Gradle section |
-| `SPACESHIP_GRADLE_SYMBOL` | `🐘️·` | Character to be shown before Gradle section |
+| `SPACESHIP_GRADLE_SYMBOL` | `⬡·` | Character to be shown before Gradle section |
 | `SPACESHIP_GRADLE_DEFAULT_VERSION` | ` ` | Gradle version to be treated as default |
 | `SPACESHIP_GRADLE_COLOR` | `green` | Color of Gradle section |
-
+| `SPACESHIP_GRADLE_JVM_SHOW` | `true` | Show JVM version used by Gradle |
+| `SPACESHIP_GRADLE_JVM_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Gradle JVM section |
+| `SPACESHIP_GRADLE_JVM_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Gradle JVM section |
+| `SPACESHIP_GRADLE_JVM_SYMBOL` | `☕️·` | Character to be shown before Gradle JVM section |
+| `SPACESHIP_GRADLE_JVM_DEFAULT_VERSION` | ` ` | Gradle JVM version to be treated as default |
+| `SPACESHIP_GRADLE_JVM_COLOR` | `magenta` | Color of Gradle JVM section |
 
 ### Terraform workspace (`terraform`)
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -554,7 +554,7 @@ SPACESHIP_KUBECONTEXT_COLOR_GROUPS=(
 
 ### Gradle (`gradle`)
 
-Shows current gradle version.
+Shows current gradle & jvm version.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
@@ -570,6 +570,25 @@ Shows current gradle version.
 | `SPACESHIP_GRADLE_JVM_SYMBOL` | `☕️·` | Character to be shown before Gradle JVM section |
 | `SPACESHIP_GRADLE_JVM_DEFAULT_VERSION` | ` ` | Gradle JVM version to be treated as default |
 | `SPACESHIP_GRADLE_JVM_COLOR` | `magenta` | Color of Gradle JVM section |
+
+### Maven (`maven`)
+
+Shows current maven & jvm version.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_MAVEN_SHOW` | `true` | Current Maven section |
+| `SPACESHIP_MAVEN_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Maven section |
+| `SPACESHIP_MAVEN_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Maven section |
+| `SPACESHIP_MAVEN_SYMBOL` | `𝑚·` | Character to be shown before Maven section |
+| `SPACESHIP_MAVEN_DEFAULT_VERSION` | ` ` | Maven version to be treated as default |
+| `SPACESHIP_MAVEN_COLOR` | `yellow` | Color of Maven section |
+| `SPACESHIP_MAVEN_JVM_SHOW` | `true` | Show JVM version used by Maven |
+| `SPACESHIP_MAVEN_JVM_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Maven JVM section |
+| `SPACESHIP_MAVEN_JVM_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Maven JVM section |
+| `SPACESHIP_MAVEN_JVM_SYMBOL` | `☕️·` | Character to be shown before Maven JVM section |
+| `SPACESHIP_MAVEN_JVM_DEFAULT_VERSION` | ` ` | Maven JVM version to be treated as default |
+| `SPACESHIP_MAVEN_JVM_COLOR` | `magenta` | Color of Maven JVM section |
 
 ### Terraform workspace (`terraform`)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
     * [Mercurial status (hg_status)](/docs/Options.md#mercurial-status-hg_status)
   * [Package version (package)](/docs/Options.md#package-version-package)
   * [Gradle (gradle)](/docs/Options.md#gradle-gradle)
+  * [Maven (maven)](/docs/Options.md#maven-maven)
   * [Node (node)](/docs/Options.md#nodejs-node)
   * [Ruby (ruby)](/docs/Options.md#ruby-ruby)
   * [Elm (elm)](/docs/Options.md#elm-elm)

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@
     * [Mercurial branch (hg_branch)](/docs/Options.md#mercurial-branch-hg_branch)
     * [Mercurial status (hg_status)](/docs/Options.md#mercurial-status-hg_status)
   * [Package version (package)](/docs/Options.md#package-version-package)
+  * [Gradle (gradle)](/docs/Options.md#gradle-gradle)
   * [Node (node)](/docs/Options.md#nodejs-node)
   * [Ruby (ruby)](/docs/Options.md#ruby-ruby)
   * [Elm (elm)](/docs/Options.md#elm-elm)

--- a/sections/gradle.zsh
+++ b/sections/gradle.zsh
@@ -31,8 +31,7 @@ spaceship::gradle::find_root_project() {
 
   while [ "$root" ] && \
         [ ! -f "$root/settings.gradle" ] && \
-        [ ! -f "$root/settings.gradle.kts" ] && \
-        [ ! -d "$root/.gradle" ]; do
+        [ ! -f "$root/settings.gradle.kts" ]; do
     root="${root%/*}"
   done
 
@@ -68,7 +67,7 @@ spaceship_gradle() {
 
   if [[ -f "$gradle_root_dir/gradlew" ]]; then
     gradle_versions=($(spaceship::gradle::versions "$gradle_root_dir/gradlew"))
-  elif spaceship::exists gralde; then
+  elif spaceship::exists gradle; then
     gradle_versions=($(spaceship::gradle::versions gradle))
   else
     return
@@ -84,7 +83,7 @@ spaceship_gradle() {
 
   [[ $SPACESHIP_GRADLE_JVM_SHOW == false ]] && return
 
-  [[ "${gradle_versions[jvm]}" == "SPACESHIP_GRADLE_JVM_DEFAULT_VERSION" ]] && return
+  [[ "${gradle_versions[jvm]}" == "$SPACESHIP_GRADLE_JVM_DEFAULT_VERSION" ]] && return
 
   spaceship::section \
     "$SPACESHIP_GRADLE_JVM_COLOR" \

--- a/sections/gradle.zsh
+++ b/sections/gradle.zsh
@@ -1,0 +1,72 @@
+#
+# Gradle
+#
+# Gradle is an open-source build automation tool focused on flexibility and performance.
+# Link: https://gradle.org/
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_GRADLE_SHOW="${SPACESHIP_GRADLE_SHOW=true}"
+SPACESHIP_GRADLE_PREFIX="${SPACESHIP_GRADLE_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_GRADLE_SUFFIX="${SPACESHIP_GRADLE_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_GRADLE_SYMBOL="${SPACESHIP_GRADLE_SYMBOL="🐘 "}"
+SPACESHIP_GRADLE_DEFAULT_VERSION="${SPACESHIP_GRADLE_DEFAULT_VERSION=""}"
+SPACESHIP_GRADLE_COLOR="${SPACESHIP_GRADLE_COLOR="green"}"
+
+# ------------------------------------------------------------------------------
+# Utils
+# ------------------------------------------------------------------------------
+
+spaceship::gradle::find_root_project() {
+  local root="$1"
+
+  while [ "$root" ] && \
+        [ ! -f "$root/settings.gradle" ] && \
+        [ ! -f "$root/settings.gradle.kts" ] && \
+        [ ! -d "$root/.gradle" ]; do
+    root="${root%/*}"
+  done
+
+  echo "$root"
+}
+
+spaceship::gradle::version() {
+  local gradle_exe="$1"
+  "$gradle_exe" --version | awk '{ if ($1 ~ /^Gradle/) { print "v" $2 } }'
+}
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show current version of gradle.
+spaceship_gradle() {
+  [[ $SPACESHIP_GRADLE_SHOW == false ]] && return
+
+  local 'gradle_root_dir'
+
+  gradle_root_dir=$(spaceship::gradle::find_root_project "$(pwd -P)")
+
+  # Show Gradle status only for applicable folders
+  [[ -n "$gradle_root_dir" ]] &>/dev/null || return
+
+  local 'gradle_version'
+
+  if [[ -f "$gradle_root_dir/gradlew" ]]; then
+    gradle_version=$(spaceship::gradle::version "$gradle_root_dir/gradlew")
+  elif spaceship::exists gralde; then
+    gradle_version=$(spaceship::gradle::version gradle)
+  else
+    return
+  fi
+
+  [[ "$gradle_version" == "$SPACESHIP_GRADLE_DEFAULT_VERSION" ]] && return
+
+  spaceship::section \
+    "$SPACESHIP_GRADLE_COLOR" \
+    "$SPACESHIP_GRADLE_PREFIX" \
+    "${SPACESHIP_GRADLE_SYMBOL}${gradle_version}" \
+    "$SPACESHIP_GRADLE_SUFFIX"
+}

--- a/sections/maven.zsh
+++ b/sections/maven.zsh
@@ -1,0 +1,97 @@
+#
+# Maven
+#
+# Apache Maven is a software project management and comprehension tool.
+# Link: https://maven.apache.org/
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_MAVEN_SHOW="${SPACESHIP_MAVEN_SHOW=true}"
+SPACESHIP_MAVEN_PREFIX="${SPACESHIP_MAVEN_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_MAVEN_SUFFIX="${SPACESHIP_MAVEN_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_MAVEN_SYMBOL="${SPACESHIP_MAVEN_SYMBOL="𝑚 "}"
+SPACESHIP_MAVEN_DEFAULT_VERSION="${SPACESHIP_MAVEN_DEFAULT_VERSION=""}"
+SPACESHIP_MAVEN_COLOR="${SPACESHIP_MAVEN_COLOR="yellow"}"
+
+SPACESHIP_MAVEN_JVM_SHOW="${SPACESHIP_MAVEN_JVM_SHOW=true}"
+SPACESHIP_MAVEN_JVM_PREFIX="${SPACESHIP_MAVEN_JVM_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_MAVEN_JVM_SUFFIX="${SPACESHIP_MAVEN_JVM_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_MAVEN_JVM_SYMBOL="${SPACESHIP_MAVEN_JVM_SYMBOL="☕️ "}"
+SPACESHIP_MAVEN_JVM_DEFAULT_VERSION="${SPACESHIP_MAVEN_JVM_DEFAULT_VERSION=""}"
+SPACESHIP_MAVEN_JVM_COLOR="${SPACESHIP_MAVEN_JVM_COLOR="magenta"}"
+
+# ------------------------------------------------------------------------------
+# Utils
+# ------------------------------------------------------------------------------
+
+spaceship::maven::find_pom() {
+  local root="$1"
+
+  while [ "$root" ] && [ ! -f "$root/pom.xml" ]; do
+    root="${root%/*}"
+  done
+
+  print "$root"
+}
+
+spaceship::maven::find_maven_wrapper() {
+  local root="$1"
+
+  while [ "$root" ] && [ ! -f "$root/mvnw" ]; do
+    root="${root%/*}"
+  done
+
+  print "$root"
+}
+
+spaceship::maven::versions() {
+  local maven_exe="$1" maven_version_output maven_version jvm_version
+
+  maven_version_output=$("$maven_exe" --version)
+  maven_version=$(echo "$maven_version_output" | awk '{ if ($2 ~ /^Maven/) { print "v" $3 } }')
+  jvm_version=$(echo "$maven_version_output" | awk '{ if ($1 ~ /^Java/) { print "v" substr($3, 1, length($3)-1) } }')
+
+  print maven "$maven_version" jvm "$jvm_version"
+}
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show current version of gradle.
+spaceship_maven() {
+  [[ $SPACESHIP_MAVEN_SHOW == false ]] && return
+
+  local maven_dir maven_exe
+
+  if maven_dir=$(spaceship::maven::find_maven_wrapper "$(pwd -P)") && [[ -n "$maven_dir" ]]; then
+    maven_exe="$maven_dir/mvnw"
+  elif spaceship::exists mvn && maven_dir=$(spaceship::maven::find_pom "$(pwd -P)") && [[ -n "$maven_dir" ]]; then
+    maven_exe="mvn"
+  else
+    return
+  fi
+
+  local -A maven_versions
+  maven_versions=($(spaceship::maven::versions "$maven_exe"))
+
+  [[ "${maven_versions[maven]}" == "$SPACESHIP_MAVEN_DEFAULT_VERSION" ]] && return
+
+  spaceship::section \
+    "$SPACESHIP_MAVEN_COLOR" \
+    "$SPACESHIP_MAVEN_PREFIX" \
+    "${SPACESHIP_MAVEN_SYMBOL}${maven_versions[maven]}" \
+    "$SPACESHIP_MAVEN_SUFFIX"
+
+  [[ $SPACESHIP_MAVEN_JVM_SHOW == false ]] && return
+
+  [[ "${maven_versions[jvm]}" == "$SPACESHIP_MAVEN_JVM_DEFAULT_VERSION" ]] && return
+
+  spaceship::section \
+    "$SPACESHIP_MAVEN_JVM_COLOR" \
+    "$SPACESHIP_MAVEN_JVM_PREFIX" \
+    "${SPACESHIP_MAVEN_JVM_SYMBOL}${maven_versions[jvm]}" \
+    "$SPACESHIP_MAVEN_JVM_SUFFIX"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -46,6 +46,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     host          # Hostname section
     git           # Git section (git_branch + git_status)
     hg            # Mercurial section (hg_branch  + hg_status)
+    gradle        # Gradle section
     package       # Package version
     node          # Node.js section
     ruby          # Ruby section

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -47,6 +47,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     git           # Git section (git_branch + git_status)
     hg            # Mercurial section (hg_branch  + hg_status)
     gradle        # Gradle section
+    maven         # Maven section
     package       # Package version
     node          # Node.js section
     ruby          # Ruby section


### PR DESCRIPTION
#### Description

Gradle and Mavenis build systems widely used by Java (and others JVM languages) developers.

##### Why one more PR with that stuff?
#265 (and #709 as it updated variant) does some things wrong.

1. Gradle detection
For gradle it tries to detect build.gradle{,.kts} file, but this is wrong - the only file required for the build is `settings.gradle` (and .kts variant). `build.gradle` may be missing completely or named differently (controlled by `settings.gradle`)
2. Multi-project builds
Former PR doesn't work in child directories, but Maven and Gradle allows running in any subproject directory - this behavior honored by this PR
3. Java version detection
It detects java version just by searching `java` in `PATH`, but that's wrong - gradle & maven could be launched with custom jvm locations (specified in their configs), not only system (default) java

#### Screenshot

![Screenshot from 2019-07-27 20-15-04](https://user-images.githubusercontent.com/1416030/61994959-682aa700-b0ac-11e9-89a7-311ef7040202.png)
