### PR TITLE
Use .gitattributes to set line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# These files should always checkout with LF line endings, even on windows.
+*.zsh-theme text eol=lf
+*.zsh text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
Summary
----------
Git on WSL can sometimes default to CFLR line endings instead of LR endings. This breaks starting spaceshipt-prompt in WSL without any clear indication of what's wrong.

Error Message
----------------
```
.oh-my-zsh/custom/themes/spaceship.zsh-theme:7: command not found: ^M
.oh-my-zsh/custom/themes/spaceship.zsh-theme:11: command not found: ^M
.oh-my-zsh/custom/themes/spaceship.zsh-theme:15: command not found: ^M
.oh-my-zsh/custom/themes/spaceship.zsh-theme:117: parse error near `elif'
```

Fix
---
Use .gitattributes to specify LR line endings for .zsh, .zsh-theme, and .sh files in this repo. I expect that for most users this change will be invisible.