### PR TITLE
Possibility to ignore specific conda env in prompt

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -440,6 +440,7 @@ Show activated conda virtual environment. Disable native conda prompt by `conda 
 | `SPACESHIP_CONDA_SYMBOL` | `🅒·` | Character to be shown before conda virtualenv section |
 | `SPACESHIP_CONDA_COLOR` | `blue` | Color of conda virtualenv environment section |
 | `SPACESHIP_CONDA_VERBOSE` | `true` | Toggle to truncate environment names under custom prefix |
+| `SPACESHIP_CONDA_IGNORE` | ` ` | Name of environment (if any) that is not to be shown |
 
 ### Pyenv (`pyenv`)
 

--- a/sections/conda.zsh
+++ b/sections/conda.zsh
@@ -14,6 +14,7 @@ SPACESHIP_CONDA_SUFFIX="${SPACESHIP_CONDA_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFF
 SPACESHIP_CONDA_SYMBOL="${SPACESHIP_CONDA_SYMBOL="🅒 "}"
 SPACESHIP_CONDA_COLOR="${SPACESHIP_CONDA_COLOR="blue"}"
 SPACESHIP_CONDA_VERBOSE="${SPACESHIP_CONDA_VERBOSE=true}"
+SPACESHIP_CONDA_IGNORE="${SPACESHIP_CONDA_IGNORE=""}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -25,6 +26,9 @@ spaceship_conda() {
 
   # Check if running via conda virtualenv
   spaceship::exists conda && [ -n "$CONDA_DEFAULT_ENV" ] || return
+
+  # Check if current conda environment is to be ignored
+  [[ -n "$SPACESHIP_CONDA_IGNORE" && "$SPACESHIP_CONDA_IGNORE" == "$CONDA_DEFAULT_ENV" ]] && return
 
   local conda_env=${CONDA_DEFAULT_ENV}
 


### PR DESCRIPTION
This adds a new option "SPACESHIP_CONDA_IGNORE" to specify a conda
environment which is not to be shown in the prompt.
This is useful when you don't care about conda's default environment
"base" and only want the environment to be shown in special cases.

<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

<!-- Describe your pull-request, what was changed and why… -->

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
