### PR TITLE
Docs: flesh out explanation of custom sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,34 @@ Spaceship works well out of the box, but you can customize almost everything if 
 - [**Options**](./docs/Options.md) — Tweak section's behavior with tons of options.
 - [**API**](./docs/API.md) — Define a custom section that will do exactly what you want.
 
-You have ability to customize or disable specific elements of Spaceship. All options must be overridden in your `.zshrc` file **after** the theme.
+You have ability to customize or disable specific elements of Spaceship. Set options and define new sections in in your `.zshrc` file, **after** the theme. To include a custom section you have defined in your prompt, add it to the `SPACESHIP_PROMPT_ORDER`.
+
+For example:
+
+```shell
+# .zshrc
+
+# add Spaceship (differs by setup, see Installating above)
+
+section_mysection() {
+  # ...
+}
+
+SPACESHIP_PROMPT_ORDER=(<any preceding sections> mysection <any following sections>)
+```
+
+To append custom sections to the default Spaceship prompt, follow the form
+
+```shell
+SPACESHIP_PROMPT_ORDER=($SPACESHIP_PROMPT_ORDER mysection)
+```
+
+To prepend custom sections to the default Spaceship prompt, follow the form
+
+```shell
+SPACESHIP_PROMPT_ORDER=(mysection $SPACESHIP_PROMPT_ORDER)
+```
+
 
 **💡 Tip:** Take a look at popular option presets or share your own configuration on [Presets](https://github.com/denysdovhan/spaceship-prompt/wiki/Presets) wiki page.
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Spaceship works well out of the box, but you can customize almost everything if 
 - [**Options**](./docs/Options.md) — Tweak section's behavior with tons of options.
 - [**API**](./docs/API.md) — Define a custom section that will do exactly what you want.
 
-You have ability to customize or disable specific elements of Spaceship. Set options and define new sections in in your `.zshrc` file, **after** the theme. To include a custom section you have defined in your prompt, add it to the `SPACESHIP_PROMPT_ORDER`.
+You have the ability to customize or disable specific elements of Spaceship. Set options and define new sections in your `.zshrc` file, **after** the theme. To include a custom section you have defined in your prompt, add it to the `SPACESHIP_PROMPT_ORDER`.
 
 For example:
 
@@ -269,13 +269,13 @@ section_mysection() {
 SPACESHIP_PROMPT_ORDER=(<any preceding sections> mysection <any following sections>)
 ```
 
-To append custom sections to the default Spaceship prompt, follow the form
+To append custom sections to the default Spaceship prompt, follow the form:
 
 ```shell
 SPACESHIP_PROMPT_ORDER=($SPACESHIP_PROMPT_ORDER mysection)
 ```
 
-To prepend custom sections to the default Spaceship prompt, follow the form
+To prepend custom sections to the default Spaceship prompt, follow the form:
 
 ```shell
 SPACESHIP_PROMPT_ORDER=(mysection $SPACESHIP_PROMPT_ORDER)

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -118,7 +118,7 @@ for section in $(spaceship::union $SPACESHIP_PROMPT_ORDER $SPACESHIP_RPROMPT_ORD
     # Custom section is declared, nothing else to do
     continue
   else
-    echo "Section '$section' have not been loaded."
+    echo "Section '$section' was not loaded."
   fi
 done
 


### PR DESCRIPTION
Hi all, hope the past ~year~ \[edit: two years?? what?!?] has treated you well! ⏳🏃‍♂️

This week a coworker of mine got interested in Spaceship, and that gave me the push I needed to look back over the project! (I still use Spaceship every day but on a now-ancient branch from the days of the modular git section convos…)

#### Description

Adds some extra documentation to the README to make it clear how custom sections work. The order bits were Inspired by #488 — what can seem obvious to someone familiar with shell scripting can be mysterious to some who isn't, and especially with macOS Catalina there are going be a more people who use the command line but don't have that scripter knowledge.