### PR TITLE
Docker: Add support for Docker contexts

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -398,12 +398,20 @@ The environment variable `COMPOSE_PATH_SEPARATOR` is supported too. For more inf
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
-| `SPACESHIP_DOCKER_SHOW` | `true` | Show current Docker version and connected docker-machine or not |
+| `SPACESHIP_DOCKER_SHOW` | `true` | Show current Docker version or not |
 | `SPACESHIP_DOCKER_PREFIX` | `on ` | Prefix before the Docker section |
 | `SPACESHIP_DOCKER_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Docker section |
 | `SPACESHIP_DOCKER_SYMBOL` | `🐳·` | Character to be shown before Docker version |
 | `SPACESHIP_DOCKER_COLOR` | `cyan` | Color of Docker section |
 | `SPACESHIP_DOCKER_VERBOSE` | `false` | Show complete Docker version |
+
+### Docker context (`docker_context`)
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_DOCKER_CONTEXT_SHOW` | `true` | Show current Docker context or not |
+| `SPACESHIP_DOCKER_CONTEXT_PREFIX` | `(` | Prefix before the Docker context section |
+| `SPACESHIP_DOCKER_CONTEXT_SUFFIX` | `)` | Suffix after the Docker context section |
 
 ### Amazon Web Services (AWS) (`aws`)
 

--- a/sections/docker.zsh
+++ b/sections/docker.zsh
@@ -46,8 +46,13 @@ spaceship_docker() {
     [[ "$compose_exists" == false ]] && return
   fi
 
+  # Docker contexts can be set using either the DOCKER_CONTEXT environment variable
+  # or the `docker context use` command. `docker context ls` will show the selected
+  # context in both cases. But we are not interested in the local "default" context.
+  local docker_context=$(docker context ls --format '{{if .Current}}{{if ne .Name "default"}}{{.Name}}{{end}}{{end}}' 2>/dev/null | tr -d '\n')
+
   # Show Docker status only for Docker-specific folders or when connected to external host
-  [[ "$compose_exists" == true || -f Dockerfile || -f docker-compose.yml || -f /.dockerenv || -n $DOCKER_MACHINE_NAME || -n $DOCKER_HOST ]] || return
+  [[ "$compose_exists" == true || -f Dockerfile || -f docker-compose.yml || -f /.dockerenv || -n $DOCKER_MACHINE_NAME || -n $DOCKER_HOST || -n $docker_context ]] || return
 
   # if docker daemon isn't running you'll get an error saying it can't connect
   local docker_version=$(docker version -f "{{.Server.Version}}" 2>/dev/null)
@@ -55,6 +60,10 @@ spaceship_docker() {
 
   [[ $SPACESHIP_DOCKER_VERBOSE == false ]] && docker_version=${docker_version%-*}
 
+  # Docker has three different ways to work on remote Docker hosts:
+  #  1. docker-machine
+  #  2. DOCKER_HOST environment variable
+  #  3. docker context (new in Docker 19.03)
   local docker_host=''
   if [[ -n $DOCKER_MACHINE_NAME ]]; then
     docker_host=" via ($DOCKER_MACHINE_NAME)"
@@ -63,6 +72,10 @@ spaceship_docker() {
   if [[ -n $DOCKER_HOST ]]; then
     # Remove protocol (tcp://) and port number from displayed Docker host
     docker_host=" via ("$(basename $DOCKER_HOST | cut -d':' -f1)")"
+  fi
+
+  if [[ -n $docker_context ]]; then
+    docker_host=" via ($docker_context)"
   fi
 
   spaceship::section \

--- a/sections/docker.zsh
+++ b/sections/docker.zsh
@@ -16,6 +16,12 @@ SPACESHIP_DOCKER_COLOR="${SPACESHIP_DOCKER_COLOR="cyan"}"
 SPACESHIP_DOCKER_VERBOSE="${SPACESHIP_DOCKER_VERBOSE=false}"
 
 # ------------------------------------------------------------------------------
+# Dependencies
+# ------------------------------------------------------------------------------
+
+source "$SPACESHIP_ROOT/sections/docker_context.zsh"
+
+# ------------------------------------------------------------------------------
 # Section
 # ------------------------------------------------------------------------------
 
@@ -46,13 +52,10 @@ spaceship_docker() {
     [[ "$compose_exists" == false ]] && return
   fi
 
-  # Docker contexts can be set using either the DOCKER_CONTEXT environment variable
-  # or the `docker context use` command. `docker context ls` will show the selected
-  # context in both cases. But we are not interested in the local "default" context.
-  local docker_context=$(docker context ls --format '{{if .Current}}{{if ne .Name "default"}}{{.Name}}{{end}}{{end}}' 2>/dev/null | tr -d '\n')
+  local docker_context="$(spaceship_docker_context)"
 
   # Show Docker status only for Docker-specific folders or when connected to external host
-  [[ "$compose_exists" == true || -f Dockerfile || -f docker-compose.yml || -f /.dockerenv || -n $DOCKER_MACHINE_NAME || -n $DOCKER_HOST || -n $docker_context ]] || return
+  [[ "$compose_exists" == true || -f Dockerfile || -f docker-compose.yml || -f /.dockerenv || -n $docker_context ]] || return
 
   # if docker daemon isn't running you'll get an error saying it can't connect
   local docker_version=$(docker version -f "{{.Server.Version}}" 2>/dev/null)
@@ -60,27 +63,9 @@ spaceship_docker() {
 
   [[ $SPACESHIP_DOCKER_VERBOSE == false ]] && docker_version=${docker_version%-*}
 
-  # Docker has three different ways to work on remote Docker hosts:
-  #  1. docker-machine
-  #  2. DOCKER_HOST environment variable
-  #  3. docker context (new in Docker 19.03)
-  local docker_host=''
-  if [[ -n $DOCKER_MACHINE_NAME ]]; then
-    docker_host=" via ($DOCKER_MACHINE_NAME)"
-  fi
-
-  if [[ -n $DOCKER_HOST ]]; then
-    # Remove protocol (tcp://) and port number from displayed Docker host
-    docker_host=" via ("$(basename $DOCKER_HOST | cut -d':' -f1)")"
-  fi
-
-  if [[ -n $docker_context ]]; then
-    docker_host=" via ($docker_context)"
-  fi
-
   spaceship::section \
     "$SPACESHIP_DOCKER_COLOR" \
     "$SPACESHIP_DOCKER_PREFIX" \
-    "${SPACESHIP_DOCKER_SYMBOL}v${docker_version}${docker_host}" \
+    "${SPACESHIP_DOCKER_SYMBOL}v${docker_version} ${docker_context}" \
     "$SPACESHIP_DOCKER_SUFFIX"
 }

--- a/sections/docker_context.zsh
+++ b/sections/docker_context.zsh
@@ -1,0 +1,44 @@
+#
+# Docker context
+#
+# Show current remote Docker context
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_DOCKER_CONTEXT_SHOW="${SPACESHIP_DOCKER_CONTEXT_SHOW=true}"
+SPACESHIP_DOCKER_CONTEXT_PREFIX="${SPACESHIP_DOCKER_CONTEXT_PREFIX="("}"
+SPACESHIP_DOCKER_CONTEXT_SUFFIX="${SPACESHIP_DOCKER_CONTEXT_SUFFIX=")"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+spaceship_docker_context() {
+  [[ $SPACESHIP_DOCKER_CONTEXT_SHOW == false ]] && return
+
+  local docker_remote_context
+
+  # Docker has three different ways to work on remote Docker hosts:
+  #  1. docker-machine
+  #  2. DOCKER_HOST environment variable
+  #  3. docker context (since Docker 19.03)
+  if [[ -n $DOCKER_MACHINE_NAME ]]; then
+    docker_remote_context="$DOCKER_MACHINE_NAME"
+  elif [[ -n $DOCKER_HOST ]]; then
+    # Remove protocol (tcp://) and port number from displayed Docker host
+    docker_remote_context="$(basename $DOCKER_HOST | cut -d':' -f1)"
+  else
+    # Docker contexts can be set using either the DOCKER_CONTEXT environment variable
+    # or the `docker context use` command. `docker context ls` will show the selected
+    # context in both cases. But we are not interested in the local "default" context.
+    docker_remote_context=$(docker context ls --format '{{if .Current}}{{if ne .Name "default"}}{{.Name}}{{end}}{{end}}' 2>/dev/null | tr -d '\n')
+  fi
+
+  spaceship::section \
+    "$SPACESHIP_DOCKER_COLOR" \
+    "$SPACESHIP_DOCKER_CONTEXT_PREFIX" \
+    "${docker_remote_context}" \
+    "$SPACESHIP_DOCKER_CONTEXT_SUFFIX"
+}


### PR DESCRIPTION
#### Description

<!-- Describe your pull-request, what was changed and why… -->
Starting Docker 19.03, "contexts" are another concept to issue Docker
commands on remote hosts. This is a follow-up PR to #699, now the Docker section covers all three ways to interact with remote Docker hosts.

Ref:
- https://docs.docker.com/engine/context/working-with-contexts/
- https://blog.mikesir87.io/2019/08/using-ssh-connections-in-docker-contexts/