### PR TITLE
Fix remove .zshrc file content when uninstall script run

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -107,10 +107,9 @@ main() {
   fi
 
   # Enabling statements for ~/.zshrc
-  msg="
-  # Set Spaceship ZSH as a prompt
-  autoload -U promptinit; promptinit
-  prompt spaceship"
+  msg="\n# Set Spaceship ZSH as a prompt"
+  msg+="\nautoload -U promptinit; promptinit"
+  msg+="\nprompt spaceship"
 
   # Check if appending was successful and perform corresponding actions
   if append_zshrc "$msg"; then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -90,7 +90,7 @@ main() {
       sed '/^# Set Spaceship ZSH as a prompt$/d' "$ZSHRC" | \
       sed '/^autoload -U promptinit; promptinit$/d' | \
       sed '/^prompt spaceship$/d' | \
-      sed  -E '/^SPACESHIP_R?PROMPT_ORDER=\([^)]*$/,/^[^(]*)/d' | \
+      sed  -E '/^SPACESHIP_R?PROMPT_ORDER=\([^)]*$/,/^[^(]*\)/d' | \
       sed '/^SPACESHIP_.*$/d' > "$ZSHRC.bak" && \
       mv -- "$ZSHRC.bak" "$ZSHRC"
     fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -69,6 +69,20 @@ rmln() {
 # Checkings and uninstalling process
 # ------------------------------------------------------------------------------
 
+remove_zshrc_content() {
+  info "Removing Spaceship from ~/.zshrc"
+  # Remove enabling statements from ~/.zshrc
+  # and remove Spaceship configuration
+  # Note: SPACESHIP_RPROMPT_ORDER and SPACESHIP_PROMPT_ORDER configuration may have multiple lines
+  # which are grouped by `(`, `)`
+  sed '/^# Set Spaceship ZSH as a prompt$/d' "$ZSHRC" | \
+  sed '/^autoload -U promptinit; promptinit$/d' | \
+  sed '/^prompt spaceship$/d' | \
+  sed  -E '/^SPACESHIP_R?PROMPT_ORDER=\([^)]*$/,/^[^(]*\)/d' | \
+  sed '/^SPACESHIP_.*$/d' > "$ZSHRC.bak" && \
+  mv -- "$ZSHRC.bak" "$ZSHRC"
+}
+
 main() {
   # Remove $GLOBAL_DEST symlink
   if [[ -L "$GLOBAL_DEST" || -L "$USER_DEST" ]]; then
@@ -80,19 +94,13 @@ main() {
 
   # Remove Spaceship from .zshrc
   if grep -q "spaceship" "$ZSHRC"; then
-    read "answer?Would you like to remove you Spaceship ZSH configuration from .zshrc? (y/N)"
-    if [[ 'y' == ${answer:l} ]]; then
-      info "Removing Spaceship from ~/.zshrc"
-      # Remove enabling statements from ~/.zshrc
-      # and remove Spaceship configuration
-      # Note: SPACESHIP_RPROMPT_ORDER and SPACESHIP_PROMPT_ORDER configuration may have multiple lines
-      # which are grouped by `(`, `)`
-      sed '/^# Set Spaceship ZSH as a prompt$/d' "$ZSHRC" | \
-      sed '/^autoload -U promptinit; promptinit$/d' | \
-      sed '/^prompt spaceship$/d' | \
-      sed  -E '/^SPACESHIP_R?PROMPT_ORDER=\([^)]*$/,/^[^(]*\)/d' | \
-      sed '/^SPACESHIP_.*$/d' > "$ZSHRC.bak" && \
-      mv -- "$ZSHRC.bak" "$ZSHRC"
+    if [[ '-y' == $1 ]]; then
+      remove_zshrc_content
+    else
+      read "answer?Would you like to remove you Spaceship ZSH configuration from .zshrc? (y/N)"
+      if [[ 'y' == ${answer:l} ]]; then
+        remove_zshrc_content
+      fi
     fi
   else
     warn "Spaceship configuration not found in ~/.zshrc!"

--- a/tests/uninstall.test.zsh
+++ b/tests/uninstall.test.zsh
@@ -35,13 +35,18 @@ test_uninstall_preserve_zshrc_content() {
 }
 
 test_uninstall_remove_spaceship_content_from_zshrc() {
+  local spaceship_promt_order_env="SPACESHIP_PROMPT_ORDER=(
+    time          # Time stampts section
+  )"
+  echo $spaceship_promt_order_env >> ~/.zshrc
+
   ./scripts/uninstall.sh -y >/dev/null
 
   zshrc_content=$(<~/.zshrc)
 
   assertNotContains "remove spaceship load comment" "$zshrc_content" "# Set Spaceship ZSH as a prompt"
   assertNotContains "remove auto load prompt init" "$zshrc_content" "autoload -U promptinit; promptinit"
-  assertNotContains "remove SPACESHIP_PROMPT_ORDER env" "$zshrc_content" "SPACESHIP_RPROMPT_ORDER"
+  assertNotContains "remove SPACESHIP_PROMPT_ORDER env" "$zshrc_content" "$spaceship_promt_order_env"
 }
 
 # ------------------------------------------------------------------------------

--- a/tests/uninstall.test.zsh
+++ b/tests/uninstall.test.zsh
@@ -25,13 +25,14 @@ setUp() {
 # ------------------------------------------------------------------------------
 
 test_uninstall_preserve_zshrc_content() {
-  echo "TEST=TEST" >> ~/.zshrc
+  local zshrc_content_to_preserve="TEST=TEST"
+  echo $zshrc_content_to_preserve >> ~/.zshrc
 
   ./scripts/uninstall.sh -y >/dev/null
 
   zshrc_content=$(<~/.zshrc)
 
-  assertContains "preserve non spaceship related install config" "$zshrc_content" "TEST=TEST"
+  assertContains "preserve non spaceship related install config" "$zshrc_content" "$zshrc_content_to_preserve"
 }
 
 test_uninstall_remove_spaceship_content_from_zshrc() {

--- a/tests/uninstall.test.zsh
+++ b/tests/uninstall.test.zsh
@@ -1,0 +1,52 @@
+#!/usr/bin/env zsh
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+# ------------------------------------------------------------------------------
+# SHUNIT2 HOOKS
+# ------------------------------------------------------------------------------
+
+oneTimeSetUp() {
+  export TERM="xterm-256color"
+
+  SPACESHIP_PROMPT_FIRST_PREFIX_SHOW=true
+  SPACESHIP_PROMPT_ADD_NEWLINE=false
+}
+
+setUp() {
+  echo "" > ~/.zshrc
+  ./scripts/install.sh >/dev/null
+}
+
+# ------------------------------------------------------------------------------
+# TEST CASES
+# ------------------------------------------------------------------------------
+
+test_uninstall_preserve_zshrc_content() {
+  echo "TEST=TEST" >> ~/.zshrc
+
+  ./scripts/uninstall.sh -y >/dev/null
+
+  zshrc_content=$(<~/.zshrc)
+
+  assertContains "preserve non spaceship related install config" "$zshrc_content" "TEST=TEST"
+}
+
+test_uninstall_remove_spaceship_content_from_zshrc() {
+  ./scripts/uninstall.sh -y >/dev/null
+
+  zshrc_content=$(<~/.zshrc)
+
+  assertNotContains "remove spaceship load comment" "$zshrc_content" "# Set Spaceship ZSH as a prompt"
+  assertNotContains "remove auto load prompt init" "$zshrc_content" "autoload -U promptinit; promptinit"
+  assertNotContains "remove SPACESHIP_PROMPT_ORDER env" "$zshrc_content" "SPACESHIP_RPROMPT_ORDER"
+}
+
+# ------------------------------------------------------------------------------
+# SHUNIT2
+# Run tests with shunit2
+# ------------------------------------------------------------------------------
+
+source modules/shunit2/shunit2


### PR DESCRIPTION
Hi 👋 

#### Description
This PR is focused to fix #773. The problem is caused because of this [line](https://github.com/denysdovhan/spaceship-prompt/blob/92463cd0cc3fb5baee60c57e505e2626c3668b8a/scripts/uninstall.sh#L93), the regular expression is invalid, so when the `sed` command runs it throws an error and the value passed to the next pipe operator is empty, because of that all the content of `.zshrc` file is deleted.

So I fixed the invalid regex (It was only a missing escape on "(") and added some tests. To test the uninstall script easily I updated the version of `shunit` because in the newer version exists there are two new functions, assertContains, and assertNotContains, that helped me. I have also removed some blank characters in enabling statements on `install.sh` script, otherwise, the uninstall script doesn't remove the enabling statements, since it doesn't...

I also have identified some potentials problems and improvements to the uninstall script. I will leave here a list of them :).

- `tput` color logic is evaluated even when `tput` is not installed. So warning messages appears in stdout.
- `$USER_SOURCE` is defined even if unused in uninstall script.
- uninstall script doesn't work well for `oh-my-zsh` instructions installation on `README.md`.
- uninstall script doesn't handle whitespaces at the beginning of each line.

CC: @Runrioter 