### PR TITLE
docker_context: Return early on empty context

### DIFF
--- a/sections/docker_context.zsh
+++ b/sections/docker_context.zsh
@@ -36,6 +36,8 @@ spaceship_docker_context() {
     docker_remote_context=$(docker context ls --format '{{if .Current}}{{if ne .Name "default"}}{{.Name}}{{end}}{{end}}' 2>/dev/null | tr -d '\n')
   fi
 
+  [[ -z $docker_remote_context ]] && return
+
   spaceship::section \
     "$SPACESHIP_DOCKER_COLOR" \
     "$SPACESHIP_DOCKER_CONTEXT_PREFIX" \


### PR DESCRIPTION
A little detail I overlooked during the refactoring: Even when there was no context set, the section would still return the formatting escape sequences `%{%B%}%{%b%}%{%B%F{cyan}%}%{%b%f%}%{%B%}%{%b%}` by default, so https://github.com/denysdovhan/spaceship-prompt/blob/master/sections/docker.zsh#L58 was always true and showed the Docker version for all directories.
