### PR TITLE
Feat yarn version

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Spaceship is a minimalistic, powerful and extremely customizable [Zsh][zsh-url] 
   - `✘` — deleted files;
 - Indicator for jobs in the background (`✦`).
 - Current Node.js version, through nvm/nodenv/n (`⬢`).
+- Current Yarn version (`🐈`).
 - Current Ruby version, through rvm/rbenv/chruby/asdf (`💎`).
 - Current Elm version (`🌳`)
 - Current Elixir version, through kiex/exenv/elixir (`💧`).

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -257,6 +257,21 @@ If you set `SPACESHIP_NODE_DEFAULT_VERSION` to the default Node.js version and y
 | `SPACESHIP_NODE_DEFAULT_VERSION` | ` ` | Node.js version to be treated as default |
 | `SPACESHIP_NODE_COLOR` | `green` | Color of Node.js section |
 
+### Yarn (`yarn`)
+
+Yarn section is shown only in directories that contain `package.json` file, or `node_modules` folder, or any other file with `.js` extension.
+
+If you set `SPACESHIP_YARN_DEFAULT_VERSION` to the default Yarn version and your current version is the same as `SPACESHIP_YARN_DEFAULT_VERSION`, then Yarn section will be hidden.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_YARN_SHOW` | `true` | Current Yarn section |
+| `SPACESHIP_YARN_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Yarn section |
+| `SPACESHIP_YARN_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Yarn section |
+| `SPACESHIP_YARN_SYMBOL` | `🐈·` | Character to be shown before Yarn version |
+| `SPACESHIP_YARN_DEFAULT_VERSION` | ` ` | Yarn version to be treated as default |
+| `SPACESHIP_YARN_COLOR` | `green` | Color of Yarn section |
+
 ### Ruby (`ruby`)
 
 Ruby section is shown only in directories that contain `Gemfile`, or `Rakefile`, or any other file with `.rb` extension.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
     * [Mercurial status (hg_status)](/docs/Options.md#mercurial-status-hg_status)
   * [Package version (package)](/docs/Options.md#package-version-package)
   * [Node (node)](/docs/Options.md#nodejs-node)
+  * [Yarn (yarn)](/docs/Options.md#yarn-yarn)
   * [Ruby (ruby)](/docs/Options.md#ruby-ruby)
   * [Elm (elm)](/docs/Options.md#elm-elm)
   * [Elixir (elixir)](/docs/Options.md#elixir-elixir)
@@ -58,4 +59,3 @@
   * [spaceship::displaytime](/docs/API.md#spaceshipdisplaytime-seconds)
   * [spaceship::union](/docs/API.md#spaceshipunion-arr1-arr2-)
 * [Troubleshooting](/docs/Troubleshooting.md)
-

--- a/sections/yarn.zsh
+++ b/sections/yarn.zsh
@@ -1,5 +1,6 @@
 #
 # Yarn
+# Module created by 🗡️ https://github.com/bouteillerAlan
 #
 # Yarn is a package manager
 # Link: https://yarnpkg.com/

--- a/sections/yarn.zsh
+++ b/sections/yarn.zsh
@@ -1,0 +1,44 @@
+#
+# Yarn
+#
+# Yarn is a package manager
+# Link: https://yarnpkg.com/
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_YARN_SHOW="${SPACESHIP_YARN_SHOW=true}"
+SPACESHIP_YARN_PREFIX="${SPACESHIP_YARN_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_YARN_SUFFIX="${SPACESHIP_YARN_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_YARN_SYMBOL="${SPACESHIP_YARN_SYMBOL="🐈 "}"
+SPACESHIP_YARN_DEFAULT_VERSION="${SPACESHIP_YARN_DEFAULT_VERSION=""}"
+SPACESHIP_YARN_COLOR="${SPACESHIP_YARN_COLOR="blue"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show current version of yarn, exception system.
+spaceship_yarn() {
+  [[ $SPACESHIP_YARN_SHOW == false ]] && return
+
+  # Show yarn status only for JS-specific folders
+  [[ -f package.json || -d node_modules || -n *.js(#qN^/) ]] || return
+
+  local 'yarn_version'
+
+  if spaceship::exists yarn; then
+    yarn_version=$(yarn -v 2>/dev/null)
+  else
+    return
+  fi
+
+  [[ $yarn_version == $SPACESHIP_YARN_DEFAULT_VERSION ]] && return
+
+  spaceship::section \
+    "$SPACESHIP_YARN_COLOR" \
+    "$SPACESHIP_YARN_PREFIX" \
+    "${SPACESHIP_YARN_SYMBOL}${yarn_version}" \
+    "$SPACESHIP_YARN_SUFFIX"
+}


### PR DESCRIPTION
#### Description

Add a section for show the current Yarn version. 

He is based on the code find in `node.zsh`.

The `npm test` pass.
