### PR TITLE
fix: change wrong env variables in Xcode section

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -301,7 +301,7 @@ Shows current version of Xcode. Local version has more priority than global.
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_XCODE_SHOW_LOCAL` | `true` | Current local Xcode version based on [xcenv] |
-| `SPACESHIP_XCODE_SHOW_GLOBAL` | `true` | Global Xcode version based on [xcenv] |
+| `SPACESHIP_XCODE_SHOW_GLOBAL` | `false` | Global Xcode version based on [xcenv] |
 | `SPACESHIP_XCODE_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Xcode section |
 | `SPACESHIP_XCODE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Xcode section |
 | `SPACESHIP_XCODE_SYMBOL` | `🛠·` | Character to be shown before Xcode version |

--- a/sections/xcode.zsh
+++ b/sections/xcode.zsh
@@ -25,9 +25,9 @@ spaceship_xcode() {
 
   local 'xcode_path'
 
-  if [[ $SPACESHIP_SWIFT_SHOW_GLOBAL == true ]] ; then
+  if [[ $SPACESHIP_XCODE_SHOW_GLOBAL == true ]] ; then
     xcode_path=$(xcenv version | sed 's/ .*//')
-  elif [[ $SPACESHIP_SWIFT_SHOW_LOCAL == true ]] ; then
+  elif [[ $SPACESHIP_XCODE_SHOW_LOCAL == true ]] ; then
     if xcenv version | grep ".xcode-version" > /dev/null; then
       xcode_path=$(xcenv version | sed 's/ .*//')
     fi


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

* Change to **SPACESHIP_XCODE_**
* Update docs
