### PR TITLE
Update slow prompt example to use kubectl_context

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -72,7 +72,7 @@ SPACESHIP_PROMPT_ORDER=(
   pyenv         # Pyenv section
   dotnet        # .NET section
   # ember       # Ember.js section (Disabled)
-  kubecontext   # Kubectl context section
+  kubectl_context   # Kubectl context section
   terraform     # Terraform workspace section
   exec_time     # Execution time
   line_sep      # Line break

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -72,7 +72,7 @@ SPACESHIP_PROMPT_ORDER=(
   pyenv         # Pyenv section
   dotnet        # .NET section
   # ember       # Ember.js section (Disabled)
-  kubectl   # Kubectl context section
+  kubectl       # Kubectl context section
   terraform     # Terraform workspace section
   exec_time     # Execution time
   line_sep      # Line break

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -72,7 +72,7 @@ SPACESHIP_PROMPT_ORDER=(
   pyenv         # Pyenv section
   dotnet        # .NET section
   # ember       # Ember.js section (Disabled)
-  kubectl_context   # Kubectl context section
+  kubectl   # Kubectl context section
   terraform     # Terraform workspace section
   exec_time     # Execution time
   line_sep      # Line break


### PR DESCRIPTION
I'm guessing the plugin name changed because it was giving me an error when I used this example `SPACESHIP_PROMPT_ORDER`.
