### PR TITLE
 Respect ZDOTDIR env var when looking for .zshrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Add `zmodule denysdovhan/spaceship-prompt --name spaceship` to your `.zimrc` and
 
 ### [antigen]
 
-Add the following snippet in your `~/.zshrc`:
+Add the following snippet in your `.zshrc`:
 
 ```
 antigen theme denysdovhan/spaceship-prompt
@@ -189,7 +189,7 @@ antibody bundle denysdovhan/spaceship-prompt
 
 ### [zinit]
 
-Add the following line to your `~/.zshrc` where you're adding your other Zsh plugins:
+Add the following line to your `.zshrc` where you're adding your other Zsh plugins:
 
 ```
 zinit light denysdovhan/spaceship-prompt
@@ -197,7 +197,7 @@ zinit light denysdovhan/spaceship-prompt
 
 ### [zgen]
 
-Add the following line to your `~/.zshrc` where you're adding your other Zsh plugins:
+Add the following line to your `.zshrc` where you're adding your other Zsh plugins:
 
 ```
 zgen load denysdovhan/spaceship-prompt spaceship
@@ -242,13 +242,13 @@ $ ln -sf "$PWD/spaceship.zsh" "/usr/local/share/zsh/site-functions/prompt_spaces
 For a user-specific installation, simply add a directory to `$fpath` for that user in `.zshrc`:
 
 ```zsh
-fpath=( "$HOME/.zfunctions" $fpath )
+fpath=( "${ZDOTDIR:-$HOME}/.zfunctions" $fpath )
 ```
 
 Then install the theme like this:
 
 ```zsh
-$ ln -sf "$PWD/spaceship.zsh" "$HOME/.zfunctions/prompt_spaceship_setup"
+$ ln -sf "$PWD/spaceship.zsh" "${ZDOTDIR:-$HOME}/.zfunctions/prompt_spaceship_setup"
 ```
 
 For initializing prompt system add this to your `.zshrc`:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,12 +25,12 @@ fi
 # Paths to important resources
 # ------------------------------------------------------------------------------
 
-ZSHRC="$HOME/.zshrc"
+ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
 REPO='https://github.com/denysdovhan/spaceship-prompt.git'
 SOURCE="$PWD/spaceship.zsh"
-USER_SOURCE="$HOME/.spaceship-prompt"
+USER_SOURCE="${ZDOTDIR:-$HOME}/.spaceship-prompt"
 DEST='/usr/local/share/zsh/site-functions'
-USER_DEST="$HOME/.zfunctions"
+USER_DEST="${ZDOTDIR:-$HOME}/.zfunctions"
 
 # ------------------------------------------------------------------------------
 # HELPERS
@@ -55,13 +55,13 @@ error()   { paint "$red"    "SPACESHIP: $@" ; }
 success() { paint "$green"  "SPACESHIP: $@" ; }
 code()    { paint "$bold"   "SPACESHIP: $@" ; }
 
-# Append text in ~/.zshrc
+# Append text in .zshrc
 # USAGE:
 #   append_zshrc [text...]
 append_zshrc() {
-  info "These lines will be added to your ~/.zshrc file:"
+  info "These lines will be added to your \"${ZDOTDIR:-$HOME}/.zshrc\" file:"
   code "$@"
-  echo "$@" >> "$HOME/.zshrc"
+  echo "$@" >> "${ZDOTDIR:-$HOME}/.zshrc"
 }
 
 # ------------------------------------------------------------------------------
@@ -75,7 +75,7 @@ main() {
   #   2. Install via curl or wget
   if [[ ! -f "$SOURCE" ]]; then
     warn "Spaceship is not present in current directory"
-    # Clone repo into the ~/..spaceship-prompt and change SOURCE
+    # Clone repo into the ${ZDOTDIR:-$HOME}/.spaceship-prompt and change SOURCE
     git clone "$REPO" "$USER_SOURCE"
     SOURCE="$USER_SOURCE/spaceship.zsh"
   else
@@ -106,7 +106,7 @@ main() {
     exit
   fi
 
-  # Enabling statements for ~/.zshrc
+  # Enabling statements for .zshrc
   msg="\n# Set Spaceship ZSH as a prompt"
   msg+="\nautoload -U promptinit; promptinit"
   msg+="\nprompt spaceship"
@@ -117,7 +117,7 @@ main() {
     echo
   else
     error "Cannot automatically insert prompt init commands."
-    error "Please insert these line into your ~/.zshrc:"
+    error "Please insert these line into your \"${ZDOTDIR:-$HOME}/.zshrc\" file:"
     code "$msg"
     exit 1
   fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -25,10 +25,10 @@ fi
 # Paths to important resources
 # ------------------------------------------------------------------------------
 
-ZSHRC="$HOME/.zshrc"
-USER_SOURCE="$HOME/.spaceship-prompt"
+ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
+USER_SOURCE="${ZDOTDIR:-$HOME}/.spaceship-prompt"
 GLOBAL_DEST="/usr/local/share/zsh/site-functions/prompt_spaceship_setup"
-USER_DEST="$HOME/.zfunctions/prompt_spaceship_setup"
+USER_DEST="${ZDOTDIR:-$HOME}/.zfunctions/prompt_spaceship_setup"
 
 # ------------------------------------------------------------------------------
 # HELPERS
@@ -70,8 +70,8 @@ rmln() {
 # ------------------------------------------------------------------------------
 
 remove_zshrc_content() {
-  info "Removing Spaceship from ~/.zshrc"
-  # Remove enabling statements from ~/.zshrc
+  info "Removing Spaceship from \"${ZDOTDIR:-$HOME}/.zshrc\""
+  # Remove enabling statements from .zshrc
   # and remove Spaceship configuration
   # Note: SPACESHIP_RPROMPT_ORDER and SPACESHIP_PROMPT_ORDER configuration may have multiple lines
   # which are grouped by `(`, `)`
@@ -103,7 +103,7 @@ main() {
       fi
     fi
   else
-    warn "Spaceship configuration not found in ~/.zshrc!"
+    warn "Spaceship configuration not found in \"${ZDOTDIR:-$HOME}/.zshrc\"!"
   fi
 
   success "Done! Spaceship installation has been removed!"

--- a/tests/uninstall.test.zsh
+++ b/tests/uninstall.test.zsh
@@ -16,7 +16,7 @@ oneTimeSetUp() {
 }
 
 setUp() {
-  echo "" > ~/.zshrc
+  echo "" > "${ZDOTDIR:-$HOME}/.zshrc"
   ./scripts/install.sh >/dev/null
 }
 
@@ -26,11 +26,11 @@ setUp() {
 
 test_uninstall_preserve_zshrc_content() {
   local zshrc_content_to_preserve="TEST=TEST"
-  echo $zshrc_content_to_preserve >> ~/.zshrc
+  echo $zshrc_content_to_preserve >> "${ZDOTDIR:-$HOME}/.zshrc"
 
   ./scripts/uninstall.sh -y >/dev/null
 
-  zshrc_content=$(<~/.zshrc)
+  zshrc_content=$(<"${ZDOTDIR:-$HOME}/.zshrc")
 
   assertContains "preserve non spaceship related install config" "$zshrc_content" "$zshrc_content_to_preserve"
 }
@@ -39,11 +39,11 @@ test_uninstall_remove_spaceship_content_from_zshrc() {
   local spaceship_promt_order_env="SPACESHIP_PROMPT_ORDER=(
     time          # Time stampts section
   )"
-  echo $spaceship_promt_order_env >> ~/.zshrc
+  echo $spaceship_promt_order_env >> "${ZDOTDIR:-$HOME}/.zshrc"
 
   ./scripts/uninstall.sh -y >/dev/null
 
-  zshrc_content=$(<~/.zshrc)
+  zshrc_content=$(<"${ZDOTDIR:-$HOME}/.zshrc")
 
   assertNotContains "remove spaceship load comment" "$zshrc_content" "# Set Spaceship ZSH as a prompt"
   assertNotContains "remove auto load prompt init" "$zshrc_content" "autoload -U promptinit; promptinit"


### PR DESCRIPTION
#### Description

The location of `.zshrc` is not always `$HOME/.zshrc`. The environment variable `ZDOTDIR` defines in which directory `.zshrc` is in. Thus this PR checks if `ZDOTDIR` is set and in that case uses it to set the `ZSHRC` variable. If `ZDOTDIR` is not set, `$HOME` is used as fallback directory.

Additionally, it changes all hardcoded references related to this issue to take `ZDOTDIR` into account.