### PR TITLE
show the ruby version even on system ruby

### DIFF
--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -30,7 +30,7 @@ spaceship_ruby() {
   if spaceship::exists rvm-prompt; then
     ruby_version=$(rvm-prompt i v g)
   elif spaceship::exists chruby; then
-    ruby_version=${$(ruby --version)[2]}
+    ruby_version=$(chruby | sed -n -e 's/ \* //p')
   elif spaceship::exists rbenv; then
     ruby_version=$(rbenv version-name)
   elif spaceship::exists asdf; then

--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -30,17 +30,17 @@ spaceship_ruby() {
   if spaceship::exists rvm-prompt; then
     ruby_version=$(rvm-prompt i v g)
   elif spaceship::exists chruby; then
-    ruby_version=$(chruby | sed -n -e 's/ \* //p')
+    ruby_version=${$(ruby --version)[2]}
   elif spaceship::exists rbenv; then
     ruby_version=$(rbenv version-name)
   elif spaceship::exists asdf; then
     # split output on space and return first element
     ruby_version=${$(asdf current ruby)[1]}
-  else
-    return
   fi
 
-  [[ -z $ruby_version || "${ruby_version}" == "system" ]] && return
+  if [[ -z $ruby_version || "${ruby_version}" == "system" ]] then
+    ruby_version=${$(ruby --version)[2]}
+  fi
 
   # Add 'v' before ruby version that starts with a number
   [[ "${ruby_version}" =~ ^[0-9].+$ ]] && ruby_version="v${ruby_version}"


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description
Sometimes you might not have a version selected by a ruby version manager like chruby or rvm so show the default system version when you want to see your ruby version

#### Screenshot
"system ruby":
![image](https://user-images.githubusercontent.com/2642545/102727897-aefaeb80-42f6-11eb-8d24-d3e70cc2fbd1.png)

No ruby usage:
![image](https://user-images.githubusercontent.com/2642545/102727914-ccc85080-42f6-11eb-87bd-9ae4dfa2aa04.png)

chruby project: 
![image](https://user-images.githubusercontent.com/2642545/102727928-dce03000-42f6-11eb-9331-4bbdfe65905b.png)
