### PR TITLE
feat: add IBM Cloud CLI section

### DIFF
--- a/sections/ibmcloud.zsh
+++ b/sections/ibmcloud.zsh
@@ -1,0 +1,37 @@
+#
+# IBM Cloud Command Line Interface
+#
+# Powerful CLIs and tooling to interact with your applications, containers, infrastructure, and other services
+# Link: https://www.ibm.com/cloud/cli
+#
+# This section shows you the current IBM Cloud account
+# Link: https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_commands_account
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_IBMCLOUD_SHOW="${SPACESHIP_IBMCLOUD_SHOW=false}"
+SPACESHIP_IBMCLOUD_PREFIX="${SPACESHIP_IBMCLOUD_PREFIX="using "}"
+SPACESHIP_IBMCLOUD_SUFFIX="${SPACESHIP_IBMCLOUD_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_IBMCLOUD_SYMBOL="${SPACESHIP_IBMCLOUD_SYMBOL="🧢 "}"
+SPACESHIP_IBMCLOUD_COLOR="${SPACESHIP_IBMCLOUD_COLOR="039"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ----------------------------------------------- -------------------------------
+
+spaceship_ibmcloud() {
+    [[ $SPACESHIP_IBMCLOUD_SHOW == false ]] && return
+
+    spaceship::exists ibmcloud || return
+
+    local ibmcloud_account=$(ibmcloud target --output json | jq -r .account.name)
+    [[ -z $ibmcloud_account ]] && return
+
+    spaceship::section \
+        "$SPACESHIP_IBMCLOUD_COLOR" \
+        "$SPACESHIP_IBMCLOUD_PREFIX" \
+        "$SPACESHIP_IBMCLOUD_SYMBOL$ibmcloud_account" \
+        "$SPACESHIP_IBMCLOUD_SUFFIX"
+}


### PR DESCRIPTION

<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

This adds a section that shows which IBM account is the active target.

#### Screenshot

![image](https://user-images.githubusercontent.com/2058315/109122035-5148ac80-7748-11eb-9e3c-dcab5f50979f.png)

