### PR TITLE
Fix: fix improper dir truncation inside git repository on Windows

### DIFF
--- a/sections/dir.zsh
+++ b/sections/dir.zsh
@@ -30,6 +30,10 @@ spaceship_dir() {
   if [[ $SPACESHIP_DIR_TRUNC_REPO == true ]] && spaceship::is_git; then
     local git_root=$(git rev-parse --show-toplevel)
 
+    if (cygpath --version) >/dev/null 2>/dev/null; then
+      git_root=$(cygpath -u $git_root)
+    fi
+
     # Check if the parent of the $git_root is "/"
     if [[ $git_root:h == / ]]; then
       trunc_prefix=/


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

On Windows, command `git rev-parse --show-toplevel` evaluates to Windows-style path.
Changes in this PR utilize `cygpath -u`, if available, to convert it to Unix-style path.

#### Screenshot

Before:
![screenshot](https://i.imgur.com/KkEjTm6.png)
After:
![screenshot](https://i.imgur.com/OqM5Wez.png)
